### PR TITLE
Add eventType and appState to API sync

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -38,6 +38,7 @@ dependencies {
     implementation("com.google.android.material:material:1.11.0")
     implementation("androidx.constraintlayout:constraintlayout:2.1.4")
     implementation("org.altbeacon:android-beacon-library:2.19.5")
+    implementation("androidx.lifecycle:lifecycle-process:2.6.2")
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")


### PR DESCRIPTION
## Summary
- include lifecycle-process dependency
- expose app state detection in `BeaconPocApplication`
- add `eventType` and `appState` fields to sync JSON payload
- send `enter`/`exit` events when beacons are detected or lost

## Testing
- `gradle test --dry-run` *(fails: plugin not found because of missing network access)*