### PR TITLE
Enable background scanning via foreground service

### DIFF
--- a/README_ANDROID.md
+++ b/README_ANDROID.md
@@ -9,7 +9,7 @@ Este projeto consiste em um beacon BLE configurado em um Adafruit nRF52840 Feath
 3.  **Notificações**: O usuário é notificado quando entra ou sai da região do beacon, mesmo com o aplicativo em segundo plano.
 4.  **Obtenção do Advertising ID**: O aplicativo obtém o AAID do dispositivo para ser enviado à API.
 5.  **Sincronização com API**: Ao detectar um beacon, o aplicativo envia o UUID, Major, Minor do beacon e o AAID do dispositivo para um endpoint de API configurável.
-6.  **Execução em Segundo Plano**: O monitoramento de beacons e as notificações funcionam mesmo quando o aplicativo está em segundo plano.
+6.  **Execução em Segundo Plano**: Um serviço de primeiro plano garante que o monitoramento de beacons e as notificações continuem funcionando mesmo quando o aplicativo está em segundo plano.
 7.  **Solicitação de Permissões**: O aplicativo lida com a solicitação das permissões necessárias em tempo de execução (Localização, Bluetooth Scan).
 
 ## Estrutura do Projeto Android (`android_app`)
@@ -62,6 +62,7 @@ Este projeto consiste em um beacon BLE configurado em um Adafruit nRF52840 Feath
 
 -   **UUID do Beacon**: O UUID `e25b8d3c-947a-452f-a13f-589cb706d2e5` está configurado no código. Se o seu beacon Arduino usar um UUID diferente, atualize-o na constante `beaconUUID` em `BeaconPocApplication.kt`.
 -   **Consumo de Bateria**: A biblioteca AltBeacon e o monitoramento em segundo plano são otimizados, mas o uso contínuo de Bluetooth e localização pode impactar a bateria. O `BackgroundPowerSaver` está habilitado para ajudar a mitigar isso.
+-   **Consumo de Bateria**: A biblioteca AltBeacon e o monitoramento em segundo plano são otimizados, mas o uso contínuo de Bluetooth e localização pode impactar a bateria. O `BackgroundPowerSaver` está habilitado para ajudar a mitigar isso e o aplicativo utiliza um serviço de primeiro plano para manter o monitoramento ativo.
 -   **Background Fetch**: A sincronização com a API ocorre quando o beacon é detectado (ao entrar na região e durante o ranging). Não foi implementado um "background fetch" no sentido de uma tarefa periódica agendada pelo sistema operacional para buscar dados da API, mas sim uma sincronização acionada por eventos de beacon. Se uma sincronização periódica independente de eventos de beacon for necessária, o WorkManager do Android seria uma boa abordagem.
 
 Este aplicativo Android fornece uma base sólida para interagir com seu beacon BLE e sincronizar dados com uma API. Sinta-se à vontade para expandir e personalizar conforme necessário.

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,6 +10,7 @@
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 
     <application
         android:name=".BeaconPocApplication"
@@ -32,7 +33,9 @@
         </activity>
 
         <!-- Serviço para monitoramento de beacons em background -->
-        <service android:name="org.altbeacon.beacon.service.BeaconService" />
+        <service
+            android:name="org.altbeacon.beacon.service.BeaconService"
+            android:foregroundServiceType="location" />
 
     </application>
 

--- a/app/src/main/java/com/example/beaconpoc/BeaconPocApplication.kt
+++ b/app/src/main/java/com/example/beaconpoc/BeaconPocApplication.kt
@@ -1,6 +1,7 @@
 package com.example.beaconpoc
 
 import android.app.Application
+import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.PendingIntent
@@ -49,6 +50,7 @@ class BeaconPocApplication : Application(), BootstrapNotifier {
         const val NOTIFICATION_CHANNEL_ID = "beacon_notifications"
         const val ENTER_NOTIFICATION_ID = 1
         const val EXIT_NOTIFICATION_ID = 2
+        const val FOREGROUND_SERVICE_NOTIFICATION_ID = 3
         // Substituir pelo endpoint real da sua API
         const val API_ENDPOINT_URL = "https://api.bearound.io/ingest" // Exemplo de URL. Mude para seu endpoint!
     }
@@ -70,6 +72,15 @@ class BeaconPocApplication : Application(), BootstrapNotifier {
         region = Region("BeaconPocRegion", Identifier.parse(beaconUUID), null, null) // Passar o UUID como String diretamente
         regionBootstrap = RegionBootstrap(this, region)
         backgroundPowerSaver = BackgroundPowerSaver(this)
+        // Habilitar escaneamento em serviço de primeiro plano para manter o app ativo em segundo plano
+        val foregroundNotification: Notification = NotificationCompat.Builder(this, NOTIFICATION_CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_launcher_foreground)
+            .setContentTitle(getString(R.string.foreground_service_title))
+            .setContentText(getString(R.string.foreground_service_message))
+            .setOngoing(true)
+            .build()
+        beaconManager.enableForegroundServiceScanning(foregroundNotification, FOREGROUND_SERVICE_NOTIFICATION_ID)
+        beaconManager.setEnableScheduledScanJobs(false)
         // BeaconManager.setDebug(true) // Para depuração
 
         // Iniciar a obtenção do Advertising ID

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -25,4 +25,6 @@
     <string name="looking_for_beacons_status">Procurando beacons...</string>
     <string name="exited_beacon_region_status">Saiu da região do beacon: %1$s</string>
     <string name="entered_beacon_region_status">Entrou na região do beacon: %1$s</string>
+    <string name="foreground_service_title">Monitoramento de Beacons</string>
+    <string name="foreground_service_message">Execução contínua em segundo plano</string>
 </resources>


### PR DESCRIPTION
## Summary
- allow beacon service to run as a foreground service
- show a persistent notification while scanning
- describe the foreground service in the documentation

## Testing
- `git log -1 --stat`