### PR TITLE
Use GH_PUSH_TOKEN for pushing Git tags

### DIFF
--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -36,12 +36,17 @@ jobs:
             echo "Tag $tag does not exist yet. Continuing..."
           fi
 
-      - name: Create Git Tag
+      - name: Create and push Git tag (using GH_PUSH_TOKEN)
         run: |
+          tag="v${{ steps.version.outputs.sdk_version }}"
+          echo "Creating and pushing tag: $tag"
           git config user.name "${{ github.actor }}"
           git config user.email "${{ github.actor }}@users.noreply.github.com"
-          git tag "v${{ steps.version.outputs.sdk_version }}"
-          git push origin "v${{ steps.version.outputs.sdk_version }}"
+          git tag "$tag"
+          # Atualiza o remote com o token de autenticação
+          git remote set-url origin https://${{ secrets.GH_PUSH_TOKEN }}@github.com/${{ github.repository }}
+          # Push da tag
+          git push origin "$tag"
 
       - name: Publish to GitHub Packages
         run: ./gradlew :sdk:publishReleasePublicationToGitHubPackagesRepository


### PR DESCRIPTION
- Modified `gradle-publish.yml` to use `GH_PUSH_TOKEN` for authenticating Git push operations.
- Updated the "Create Git Tag" step to "Create and push Git tag (using GH_PUSH_TOKEN)".
- The Git remote URL is now set using the `GH_PUSH_TOKEN` secret before pushing the tag.