### PR TITLE
Configure git credentials for tagging and publishing

### DIFF
--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -12,6 +12,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up JDK
         uses: actions/setup-java@v4
@@ -43,9 +44,7 @@ jobs:
           git config user.name "${{ github.actor }}"
           git config user.email "${{ github.actor }}@users.noreply.github.com"
           git tag "$tag"
-          # Atualiza o remote com o token de autenticação
           git remote set-url origin https://${{ secrets.GH_PUSH_TOKEN }}@github.com/${{ github.repository }}
-          # Push da tag
           git push origin "$tag"
 
       - name: Publish to GitHub Packages


### PR DESCRIPTION
- Set `persist-credentials` to `false` in `actions/checkout@v4`.
- Removed comments explaining git commands in the "Create and Push Tag" step.