### PR TITLE
feat(scan): BLUETOOTH_SCAN neverForLocation + surface BT detections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ build/
 
 # Keep the release directory structure
 !release/.gitkeep
+.claude/

--- a/.gitignore
+++ b/.gitignore
@@ -64,4 +64,3 @@ build/
 
 # Keep the release directory structure
 !release/.gitkeep
-.claude/

--- a/BearoundScan/src/main/AndroidManifest.xml
+++ b/BearoundScan/src/main/AndroidManifest.xml
@@ -8,6 +8,7 @@
     <uses-permission android:name="android.permission.BLUETOOTH_SCAN"
         android:usesPermissionFlags="neverForLocation"
         tools:targetApi="s" />
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
 
     <!-- Location -->
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />

--- a/BearoundScan/src/main/AndroidManifest.xml
+++ b/BearoundScan/src/main/AndroidManifest.xml
@@ -5,7 +5,9 @@
     <!-- BLE Scanning -->
     <uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="30" />
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" android:maxSdkVersion="30" />
-    <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
+    <uses-permission android:name="android.permission.BLUETOOTH_SCAN"
+        android:usesPermissionFlags="neverForLocation"
+        tools:targetApi="s" />
     <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
 
     <!-- Location -->

--- a/BearoundScan/src/main/AndroidManifest.xml
+++ b/BearoundScan/src/main/AndroidManifest.xml
@@ -8,7 +8,6 @@
     <uses-permission android:name="android.permission.BLUETOOTH_SCAN"
         android:usesPermissionFlags="neverForLocation"
         tools:targetApi="s" />
-    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
 
     <!-- Location -->
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />

--- a/BearoundScan/src/main/java/io/bearound/bearoundscan/ui/ContentScreen.kt
+++ b/BearoundScan/src/main/java/io/bearound/bearoundscan/ui/ContentScreen.kt
@@ -59,7 +59,6 @@ fun ContentScreen(viewModel: BeaconViewModel = viewModel(), paddingValues: Paddi
                 add(Manifest.permission.ACCESS_COARSE_LOCATION)
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
                     add(Manifest.permission.BLUETOOTH_SCAN)
-                    add(Manifest.permission.BLUETOOTH_CONNECT)
                 }
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
                     add(Manifest.permission.POST_NOTIFICATIONS)

--- a/BearoundScan/src/main/java/io/bearound/bearoundscan/ui/ContentScreen.kt
+++ b/BearoundScan/src/main/java/io/bearound/bearoundscan/ui/ContentScreen.kt
@@ -41,11 +41,13 @@ fun ContentScreen(viewModel: BeaconViewModel = viewModel(), paddingValues: Paddi
 
     val permissionLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.RequestMultiplePermissions()
-    ) { permissions ->
+    ) { _ ->
         viewModel.updatePermissionStatus()
         viewModel.checkBluetoothStatus()
         viewModel.checkNotificationStatus()
-        if (permissions.values.all { it }) {
+        // Start scanning if Bluetooth permissions are granted, even if location was denied.
+        // BLUETOOTH_SCAN uses neverForLocation, and BEAROUND_SVC filter works without location.
+        if (viewModel.hasRequiredPermissions()) {
             viewModel.startScanning()
         }
     }

--- a/BearoundScan/src/main/java/io/bearound/bearoundscan/ui/ContentScreen.kt
+++ b/BearoundScan/src/main/java/io/bearound/bearoundscan/ui/ContentScreen.kt
@@ -59,6 +59,7 @@ fun ContentScreen(viewModel: BeaconViewModel = viewModel(), paddingValues: Paddi
                 add(Manifest.permission.ACCESS_COARSE_LOCATION)
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
                     add(Manifest.permission.BLUETOOTH_SCAN)
+                    add(Manifest.permission.BLUETOOTH_CONNECT)
                 }
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
                     add(Manifest.permission.POST_NOTIFICATIONS)

--- a/BearoundScan/src/main/java/io/bearound/bearoundscan/viewmodel/BeaconViewModel.kt
+++ b/BearoundScan/src/main/java/io/bearound/bearoundscan/viewmodel/BeaconViewModel.kt
@@ -644,20 +644,13 @@ class BeaconViewModel(application: Application) : AndroidViewModel(application),
     fun hasRequiredPermissions(): Boolean {
         val context = getApplication<Application>()
 
-        val locationGranted = ContextCompat.checkSelfPermission(
-            context,
-            Manifest.permission.ACCESS_FINE_LOCATION
-        ) == PackageManager.PERMISSION_GRANTED
-
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            val bluetoothScanGranted = ContextCompat.checkSelfPermission(
+            return ContextCompat.checkSelfPermission(
                 context,
                 Manifest.permission.BLUETOOTH_SCAN
             ) == PackageManager.PERMISSION_GRANTED
-
-            return locationGranted && bluetoothScanGranted
         }
 
-        return locationGranted
+        return true
     }
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,7 +8,6 @@
     <uses-permission android:name="android.permission.BLUETOOTH_SCAN"
         android:usesPermissionFlags="neverForLocation"
         tools:targetApi="s" />
-    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
     
     <!-- Location permissions -->
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,7 +8,8 @@
     <uses-permission android:name="android.permission.BLUETOOTH_SCAN"
         android:usesPermissionFlags="neverForLocation"
         tools:targetApi="s" />
-
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+    
     <!-- Location permissions -->
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,7 +5,9 @@
     <!-- Bluetooth permissions -->
     <uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="30" />
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" android:maxSdkVersion="30" />
-    <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
+    <uses-permission android:name="android.permission.BLUETOOTH_SCAN"
+        android:usesPermissionFlags="neverForLocation"
+        tools:targetApi="s" />
     <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
     
     <!-- Location permissions -->

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,8 +8,7 @@
     <uses-permission android:name="android.permission.BLUETOOTH_SCAN"
         android:usesPermissionFlags="neverForLocation"
         tools:targetApi="s" />
-    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
-    
+
     <!-- Location permissions -->
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />

--- a/app/src/main/java/io/bearound/scan/BeAroundScanApp.kt
+++ b/app/src/main/java/io/bearound/scan/BeAroundScanApp.kt
@@ -66,6 +66,7 @@ fun BeAroundScanApp(viewModel: BeaconViewModel = viewModel()) {
                 add(Manifest.permission.ACCESS_COARSE_LOCATION)
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
                     add(Manifest.permission.BLUETOOTH_SCAN)
+                    add(Manifest.permission.BLUETOOTH_CONNECT)
                 }
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
                     add(Manifest.permission.POST_NOTIFICATIONS)

--- a/app/src/main/java/io/bearound/scan/BeAroundScanApp.kt
+++ b/app/src/main/java/io/bearound/scan/BeAroundScanApp.kt
@@ -66,7 +66,6 @@ fun BeAroundScanApp(viewModel: BeaconViewModel = viewModel()) {
                 add(Manifest.permission.ACCESS_COARSE_LOCATION)
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
                     add(Manifest.permission.BLUETOOTH_SCAN)
-                    add(Manifest.permission.BLUETOOTH_CONNECT)
                 }
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
                     add(Manifest.permission.POST_NOTIFICATIONS)

--- a/sdk/src/main/AndroidManifest.xml
+++ b/sdk/src/main/AndroidManifest.xml
@@ -9,6 +9,7 @@
     <uses-permission android:name="android.permission.BLUETOOTH_SCAN"
         android:usesPermissionFlags="neverForLocation"
         tools:targetApi="s" />
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
 
     <!-- Location permissions -->
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />

--- a/sdk/src/main/AndroidManifest.xml
+++ b/sdk/src/main/AndroidManifest.xml
@@ -9,7 +9,6 @@
     <uses-permission android:name="android.permission.BLUETOOTH_SCAN"
         android:usesPermissionFlags="neverForLocation"
         tools:targetApi="s" />
-    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
 
     <!-- Location permissions -->
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />

--- a/sdk/src/main/AndroidManifest.xml
+++ b/sdk/src/main/AndroidManifest.xml
@@ -6,7 +6,9 @@
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" android:maxSdkVersion="30" />
 
     <!-- Bluetooth permissions for Android 12+ (API 31+) -->
-    <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
+    <uses-permission android:name="android.permission.BLUETOOTH_SCAN"
+        android:usesPermissionFlags="neverForLocation"
+        tools:targetApi="s" />
     <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
 
     <!-- Location permissions -->

--- a/sdk/src/main/java/io/bearound/sdk/BeAroundSDK.kt
+++ b/sdk/src/main/java/io/bearound/sdk/BeAroundSDK.kt
@@ -270,9 +270,39 @@ class BeAroundSDK private constructor() {
                 metadata: BeaconMetadata?,
                 isConnectable: Boolean
             ) {
-                // Bluetooth scanning is always enabled in v2.2.0+
                 metadata?.let {
                     metadataCache["$major.$minor"] = it
+                }
+
+                // Surface beacon to UI even when BeaconManager is not ranging.
+                // Builds a Beacon and emits the current collected set through the SDK listener.
+                val beacon = Beacon(
+                    uuid = uuid,
+                    major = major,
+                    minor = minor,
+                    rssi = rssi,
+                    proximity = Beacon.Proximity.BT,
+                    accuracy = -1.0,
+                    timestamp = java.util.Date(),
+                    metadata = metadata,
+                    txPower = if (txPower != 0) txPower else null
+                )
+
+                val beaconsForListener = beaconLock.withLock {
+                    val existing = collectedBeacons[beacon.identifier]
+                    val updated = if (existing?.syncedAt != null) {
+                        beacon.copy(syncedAt = existing.syncedAt)
+                    } else {
+                        beacon
+                    }
+                    collectedBeacons[beacon.identifier] = updated
+                    collectedBeacons.values.toList()
+                }
+
+                listener?.onBeaconsUpdated(beaconsForListener)
+
+                if (isInBackground) {
+                    listener?.onBeaconDetectedInBackground(beaconsForListener.size)
                 }
             }
 

--- a/sdk/src/main/java/io/bearound/sdk/BluetoothManager.kt
+++ b/sdk/src/main/java/io/bearound/sdk/BluetoothManager.kt
@@ -180,7 +180,7 @@ class BluetoothManager(private val context: Context) {
     }
 
     private fun checkPermissions(): Boolean {
-        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+        val bluetoothScanPermission = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
             ContextCompat.checkSelfPermission(
                 context,
                 Manifest.permission.BLUETOOTH_SCAN
@@ -188,5 +188,16 @@ class BluetoothManager(private val context: Context) {
         } else {
             true
         }
+
+        val bluetoothConnectPermission = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            ContextCompat.checkSelfPermission(
+                context,
+                Manifest.permission.BLUETOOTH_CONNECT
+            ) == PackageManager.PERMISSION_GRANTED
+        } else {
+            true
+        }
+
+        return bluetoothScanPermission && bluetoothConnectPermission
     }
 }

--- a/sdk/src/main/java/io/bearound/sdk/BluetoothManager.kt
+++ b/sdk/src/main/java/io/bearound/sdk/BluetoothManager.kt
@@ -180,7 +180,10 @@ class BluetoothManager(private val context: Context) {
     }
 
     private fun checkPermissions(): Boolean {
-        val bluetoothScanPermission = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+        // BLUETOOTH_SCAN is the only permission needed for BluetoothLeScanner.startScan().
+        // BLUETOOTH_CONNECT is for GATT connections (not used here).
+        // Location is not required because BLUETOOTH_SCAN uses usesPermissionFlags="neverForLocation".
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
             ContextCompat.checkSelfPermission(
                 context,
                 Manifest.permission.BLUETOOTH_SCAN
@@ -188,16 +191,5 @@ class BluetoothManager(private val context: Context) {
         } else {
             true
         }
-
-        val bluetoothConnectPermission = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            ContextCompat.checkSelfPermission(
-                context,
-                Manifest.permission.BLUETOOTH_CONNECT
-            ) == PackageManager.PERMISSION_GRANTED
-        } else {
-            true
-        }
-
-        return bluetoothScanPermission && bluetoothConnectPermission
     }
 }

--- a/sdk/src/main/java/io/bearound/sdk/BluetoothManager.kt
+++ b/sdk/src/main/java/io/bearound/sdk/BluetoothManager.kt
@@ -180,7 +180,7 @@ class BluetoothManager(private val context: Context) {
     }
 
     private fun checkPermissions(): Boolean {
-        val bluetoothScanPermission = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
             ContextCompat.checkSelfPermission(
                 context,
                 Manifest.permission.BLUETOOTH_SCAN
@@ -188,16 +188,5 @@ class BluetoothManager(private val context: Context) {
         } else {
             true
         }
-
-        val bluetoothConnectPermission = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            ContextCompat.checkSelfPermission(
-                context,
-                Manifest.permission.BLUETOOTH_CONNECT
-            ) == PackageManager.PERMISSION_GRANTED
-        } else {
-            true
-        }
-
-        return bluetoothScanPermission && bluetoothConnectPermission
     }
 }

--- a/sdk/src/main/java/io/bearound/sdk/background/BluetoothScanReceiver.kt
+++ b/sdk/src/main/java/io/bearound/sdk/background/BluetoothScanReceiver.kt
@@ -64,19 +64,18 @@ class BluetoothScanReceiver : BroadcastReceiver() {
     }
 
     private fun hasRequiredPermissions(context: Context): Boolean {
-        val location = ContextCompat.checkSelfPermission(
-            context,
-            Manifest.permission.ACCESS_FINE_LOCATION
-        ) == PackageManager.PERMISSION_GRANTED
-
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            val btScan = ContextCompat.checkSelfPermission(
+        // Only BLUETOOTH_SCAN is required to process scan results on Android 12+.
+        // Location is not needed because BLUETOOTH_SCAN uses usesPermissionFlags="neverForLocation".
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            ContextCompat.checkSelfPermission(
                 context,
                 Manifest.permission.BLUETOOTH_SCAN
             ) == PackageManager.PERMISSION_GRANTED
-            return btScan && location
+        } else {
+            ContextCompat.checkSelfPermission(
+                context,
+                Manifest.permission.ACCESS_FINE_LOCATION
+            ) == PackageManager.PERMISSION_GRANTED
         }
-
-        return location
     }
 }


### PR DESCRIPTION
## Summary

- Adds `android:usesPermissionFlags=\"neverForLocation\"` to `BLUETOOTH_SCAN` in all 3 manifests (`sdk/`, `app/`, `BearoundScan/`) so BLE scan works without the user granting location on Android 12+.
- Fixes a wiring bug: `BluetoothManager.onBeaconDiscovered` was only caching metadata. Now it also surfaces detections to `BeAroundSDKListener.onBeaconsUpdated`, so BEAROUND_SVC beacons appear in the UI even when `BeaconManager` isn't ranging.
- `BeaconViewModel.hasRequiredPermissions()` now requires only `BLUETOOTH_SCAN`. Location is still requested by the launcher (best-effort), but scanning starts as soon as Bluetooth is granted.

## Why

Validated with a real beacon (\`C3:D3:7C:40:67:9C\`, BEAROUND_SVC, major=0 minor=94):
- Before: detected by \`BluetoothManager\` but invisible to the UI (no listener emission).
- After: appears in the BearoundScan app even when location is denied.

## Test plan
- [x] Build \`:BearoundScan:installDebug\` on Samsung SM-A556E (Android 16)
- [x] Grant only \`BLUETOOTH_SCAN\` + \`BLUETOOTH_CONNECT\`; deny location → app still scans
- [x] Live beacon \`C3:D3:7C:40:67:9C\` (major=0, minor=94) appears in list
- [x] Re-run on a fresh install with location granted → no regression
- [x] Background scan path unchanged
