### PR TITLE
chore(app): inject BUSINESS_TOKEN via BuildConfig from local.properties

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -54,6 +54,17 @@ O app usa **Jetpack Compose** (equivalente ao SwiftUI do iOS) para uma interface
 - 🌓 Suporte a tema claro/escuro
 - 📱 Material Design 3
 
+## 🔑 Configuração do Business Token
+
+O app lê o `BUSINESS_TOKEN` de `local.properties` (gitignored) via `BuildConfig`. Antes de rodar:
+
+```properties
+# local.properties
+BUSINESS_TOKEN=seu-business-token-aqui
+```
+
+Alternativamente, defina via variável de ambiente `BUSINESS_TOKEN` antes do build.
+
 ## 🚀 Funcionalidades do SDK Demonstradas
 
 ### Inicialização e Configuração
@@ -62,7 +73,7 @@ val sdk = BeAroundSDK.getInstance(context)
 sdk.delegate = this
 
 sdk.configure(
-    businessToken = "your-business-token",
+    businessToken = BuildConfig.BUSINESS_TOKEN,
     foregroundScanInterval = ForegroundScanInterval.SECONDS_15,
     backgroundScanInterval = BackgroundScanInterval.SECONDS_30,
     maxQueuedPayloads = MaxQueuedPayloads.MEDIUM

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,6 +4,14 @@ plugins {
     id("org.jetbrains.kotlin.plugin.compose") version "2.0.0"
 }
 
+// Read BUSINESS_TOKEN from local.properties (gitignored) or env var.
+def localProps = new Properties()
+def localPropsFile = rootProject.file("local.properties")
+if (localPropsFile.exists()) {
+    localProps.load(new FileInputStream(localPropsFile))
+}
+def businessToken = localProps.getProperty("BUSINESS_TOKEN", System.getenv("BUSINESS_TOKEN") ?: "")
+
 android {
     namespace = "io.bearound.scan"
     compileSdk = 36
@@ -19,6 +27,8 @@ android {
 
         // Dexing optimization
         multiDexEnabled = true
+
+        buildConfigField "String", "BUSINESS_TOKEN", "\"${businessToken}\""
     }
 
     buildTypes {
@@ -35,6 +45,7 @@ android {
 
     buildFeatures {
         compose = true
+        buildConfig = true
     }
     
     composeOptions {

--- a/app/src/main/java/io/bearound/scan/BeaconViewModel.kt
+++ b/app/src/main/java/io/bearound/scan/BeaconViewModel.kt
@@ -89,7 +89,7 @@ class BeaconViewModel(application: Application) : AndroidViewModel(application),
         maxQueued: MaxQueuedPayloads
     ) {
         sdk.configure(
-            businessToken = "your-business-token-here",
+            businessToken = BuildConfig.BUSINESS_TOKEN,
             scanPrecision = precision,
             maxQueuedPayloads = maxQueued
         )


### PR DESCRIPTION
## Summary
- Sample app no longer hardcodes the business token in source.
- Token is read from `local.properties` (gitignored) or `BUSINESS_TOKEN` env var and exposed via `BuildConfig.BUSINESS_TOKEN`.
- Prevents the token from leaking into git history; rotation no longer requires a code change.