### PR TITLE
docs(android): hybrid wake-up + English-first defaults

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,11 +1,11 @@
-# CHANGES — Migração para Service Data (UUID 0xBEAD)
+# CHANGES — Migration to Service Data (UUID 0xBEAD)
 
 ## IBeaconParser.kt
 
-### Novo: `BEAD_SERVICE_UUID`
-Constante `ParcelUuid` para o UUID 16-bit `0xBEAD` em formato 128-bit (`0000BEAD-0000-1000-8000-00805F9B34FB`).
+### New: `BEAD_SERVICE_UUID`
+A `ParcelUuid` constant for the 16-bit `0xBEAD` UUID expressed in 128-bit form (`0000BEAD-0000-1000-8000-00805F9B34FB`).
 
-### Nova data class: `BeadServiceData`
+### New data class: `BeadServiceData`
 ```kotlin
 data class BeadServiceData(
     val major: Int,
@@ -15,10 +15,10 @@ data class BeadServiceData(
 )
 ```
 
-### Novo método: `parseServiceData(scanRecord, rssi)`
-Parseia o payload binário de 11 bytes (Little-Endian) do Service Data com UUID `0xBEAD` via `ScanRecord.getServiceData()`:
+### New method: `parseServiceData(scanRecord, rssi)`
+Parses the 11-byte (little-endian) Service Data payload under UUID `0xBEAD` via `ScanRecord.getServiceData()`:
 
-| Offset | Bytes | Campo       | Tipo      |
+| Offset | Bytes | Field       | Type      |
 |--------|-------|-------------|-----------|
 | 0-1    | 2     | Firmware    | uint16 LE |
 | 2-3    | 2     | Major       | uint16 LE |
@@ -27,46 +27,46 @@ Parseia o payload binário de 11 bytes (Little-Endian) do Service Data com UUID 
 | 8      | 1     | Temperature | int8      |
 | 9-10   | 2     | Battery mV  | uint16 LE |
 
-Retorna `BeadServiceData` com `BeaconMetadata` preenchido, ou `null` se não presente/inválido.
+Returns `BeadServiceData` with a populated `BeaconMetadata`, or `null` if the data is missing or invalid.
 
 ---
 
 ## BeaconManager.kt
 
-### Atualizado: `startRanging()`
-Adicionado segundo `ScanFilter` para BEAD Service Data:
+### Updated: `startRanging()`
+Added a second `ScanFilter` for BEAD Service Data:
 ```kotlin
 ScanFilter.Builder()
     .setServiceData(IBeaconParser.BEAD_SERVICE_UUID, byteArrayOf(), byteArrayOf())
     .build()
 ```
-Os filtros funcionam como OR — um scan result que case com qualquer um dos dois (iBeacon OU BEAD Service Data) será entregue.
+The filters are combined with OR semantics — a scan result that matches either path (iBeacon OR BEAD Service Data) is delivered.
 
-### Reescrito: `processScanResult()`
-Nova lógica de prioridade:
-1. **BEAD Service Data** → major, minor E metadata completa
-2. **iBeacon manufacturer data** → major, minor sem metadata (fallback)
+### Rewritten: `processScanResult()`
+New priority logic:
+1. **BEAD Service Data** → major, minor AND full metadata
+2. **iBeacon manufacturer data** → major, minor without metadata (fallback)
 
 ---
 
 ## BluetoothManager.kt
 
-### Reescrito: `processScanResult()`
-Mesma lógica de prioridade do BeaconManager:
-1. **BEAD Service Data** → major, minor E metadata completa
-2. **iBeacon manufacturer data** → major, minor sem metadata (fallback)
+### Rewritten: `processScanResult()`
+Same priority logic as BeaconManager:
+1. **BEAD Service Data** → major, minor AND full metadata
+2. **iBeacon manufacturer data** → major, minor without metadata (fallback)
 
-### Removido: `parseBeaconMetadata()`
-Parsing do nome `"B:firmware_?_battery_movements_temperature"` foi removido.
+### Removed: `parseBeaconMetadata()`
+Parsing of the name-based `"B:firmware_?_battery_movements_temperature"` payload was removed.
 
-### Simplificada deduplicação
-`shouldProcessBeacon()` agora usa chave `"major.minor"` em vez de `"uuid-major-minor"`.
+### Simplified deduplication
+`shouldProcessBeacon()` now keys on `"major.minor"` instead of `"uuid-major-minor"`.
 
 ---
 
-## Mudanças nos campos
-- **battery**: agora recebe millivolts (ex: 3269) em vez de porcentagem (0-100)
-- **firmware**: agora recebe integer como string (ex: "1") em vez de versão semântica (ex: "2.1.0")
+## Field changes
+- **battery**: now reported in millivolts (e.g., `3269`) instead of a 0-100 percentage
+- **firmware**: now reported as an integer-as-string (e.g., `"1"`) instead of a semantic version (e.g., `"2.1.0"`)
 
 ## Backward compatibility
-Beacons com firmware antigo (Name-based) **não serão mais detectados** — intencional.
+Beacons running the old name-based firmware **will no longer be detected** — intentional.

--- a/README.md
+++ b/README.md
@@ -244,16 +244,57 @@ class MainActivity : AppCompatActivity(), BeAroundSDKListener {
 ```
 
 **How it works:**
-- System automatically wakes up the app when iBeacon is detected
+- System automatically wakes up the app when an iBeacon is detected
 - No notification required
 - Real-time detection
-- No foreground service required
+- No foreground service required for Android 14+
 
 **Important Notes:**
 - Background scanning requires `ACCESS_BACKGROUND_LOCATION` permission
-- WorkManager minimum interval is 15 minutes (Android limitation)
+- WorkManager's minimum interval is 15 minutes (Android limitation)
 - Android may delay scans in battery saver mode
-- Background scanning continues even after device reboot
+- Background scanning continues even after device reboot via `BOOT_COMPLETED`
+
+### Terminated App Detection
+
+The SDK is designed to survive every state where the app is not running — including a user **force-stop** or **swipe from recents** — without any code change on the host side. This is the same posture the iOS SDK delivers only when the user opts into the Location eye; on Android it is the default.
+
+| Scenario | Detection still works? | Mechanism |
+|---|---|---|
+| App in foreground | ✅ | `BluetoothLeScanner` with `ScanCallback` |
+| App in background | ✅ | Same callback, OS keeps process alive briefly |
+| App killed by **system** (memory / battery pressure) | ✅ | `PendingIntent` broadcast scan → `BluetoothScanReceiver` wakes a fresh process |
+| App killed by **user** (swipe from recents) | ✅ on **Android 14+** | Same `PendingIntent` scan — kernel-registered, survives swipe |
+| App **force-stopped** in Settings | ✅ on **Android 14+** | Same `PendingIntent` scan, re-registered on next interaction |
+| After device reboot | ✅ | `BOOT_COMPLETED` → `ScanWatchdogReceiver` re-arms the scan |
+
+**Architecture under the hood:**
+
+- **`BluetoothScanReceiver`** — wakes the app via `PendingIntent` when a matching iBeacon is observed by the OS scanner. Equivalent to iOS's `CLBeaconRegion` `didEnterRegion` callback, but **does not require Location authorization beyond `ACCESS_BACKGROUND_LOCATION`** (which is required for any BLE scan in background on Android).
+- **`ScanWatchdogReceiver`** — `AlarmManager` heartbeat every 15 min, plus `BOOT_COMPLETED` listener. Re-registers the BLE scan filter if it ever gets evicted by the OS.
+- **`BeaconScanService`** — optional foreground service for apps targeting Android 13 or below, or for apps that need a visible "scanning" indicator. Not needed on Android 14+.
+
+#### Android version baseline
+
+| Android version | Force-stop survival without foreground service |
+|---|---|
+| 14+ (API 34+) | ✅ Default behavior |
+| 8 – 13 (API 26 – 33) | Partial — recommend enabling the foreground service (`enableForegroundScanning(...)`) |
+| < 8 (API < 26) | Not supported — the SDK requires API 26+ |
+
+#### OEM caveat (the part not in the docs of any beacon SDK)
+
+Stock Android (Pixel) honors the `PendingIntent` scan exactly as documented. Several OEMs ship aggressive battery managers that kill third-party `PendingIntent` and broadcast receivers regardless of Android version:
+
+| OEM | Behavior | Mitigation |
+|---|---|---|
+| Samsung (One UI 6+) | Generally honors the scan; some restrictions on apps marked "Sleeping" | Ask user to add app to "Never sleeping apps" |
+| Xiaomi / Redmi (MIUI / HyperOS) | Aggressively kills background broadcast receivers | Ask user to enable "Autostart" + lock app in recents |
+| Huawei / Honor (EMUI / HarmonyOS) | Same as Xiaomi | "Manage manually" in battery settings |
+| OnePlus (OxygenOS 11+) | Less aggressive but still restricts | Disable "Deep optimization" for the app |
+| Pixel / Stock | Honors PendingIntent scan | No action |
+
+For any of these vendors, the host app should request `REQUEST_IGNORE_BATTERY_OPTIMIZATIONS` and link to the relevant settings page. Without that, the OEM's killer can evict the SDK even on Android 14+. See [dontkillmyapp.com](https://dontkillmyapp.com) for the full per-vendor matrix.
 
 ## Configuration Options
 

--- a/sdk/src/main/java/io/bearound/sdk/background/BeaconScanService.kt
+++ b/sdk/src/main/java/io/bearound/sdk/background/BeaconScanService.kt
@@ -73,7 +73,7 @@ class BeaconScanService : Service() {
 
     private var currentIcon: Int? = null
     private var currentChannelId: String? = null
-    private var currentChannelName: String = "Serviço de monitoramento da região"
+    private var currentChannelName: String = "Region monitoring service"
 
     override fun onCreate() {
         super.onCreate()
@@ -84,7 +84,7 @@ class BeaconScanService : Service() {
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         val rawTitle = intent?.getStringExtra(EXTRA_TITLE) ?: ""
         val title = rawTitle.ifEmpty { resolveAppName() }
-        val text = intent?.getStringExtra(EXTRA_TEXT) ?: "Encontrando promoções"
+        val text = intent?.getStringExtra(EXTRA_TEXT) ?: "Scanning for nearby content"
         val isUpdateOnly = intent?.getBooleanExtra(EXTRA_UPDATE_ONLY, false) ?: false
 
         if (isUpdateOnly) {
@@ -97,7 +97,7 @@ class BeaconScanService : Service() {
 
         val icon = intent?.getIntExtra(EXTRA_ICON, 0)?.takeIf { it != 0 }
         val channelId = intent?.getStringExtra(EXTRA_CHANNEL_ID)
-        val channelName = intent?.getStringExtra(EXTRA_CHANNEL_NAME) ?: "Serviço de monitoramento da região"
+        val channelName = intent?.getStringExtra(EXTRA_CHANNEL_NAME) ?: "Region monitoring service"
 
         currentIcon = icon
         currentChannelId = channelId

--- a/sdk/src/main/java/io/bearound/sdk/interfaces/BeAroundSDKListener.kt
+++ b/sdk/src/main/java/io/bearound/sdk/interfaces/BeAroundSDKListener.kt
@@ -63,7 +63,7 @@ interface BeAroundSDKListener {
     /**
      * Called when beacons are detected in background with foreground service active.
      * Return a [NotificationContent] to update the notification with contextual info
-     * (e.g., "Você está perto de [local]"), or null to keep the default text.
+     * (e.g., "You're near [location]"), or null to keep the default text.
      *
      * @param beacons Currently detected beacons
      * @return Custom notification content, or null to keep defaults from [ForegroundScanConfig]

--- a/sdk/src/main/java/io/bearound/sdk/models/ForegroundScanConfig.kt
+++ b/sdk/src/main/java/io/bearound/sdk/models/ForegroundScanConfig.kt
@@ -10,24 +10,24 @@ package io.bearound.sdk.models
  * **Notification title**: defaults to the host app name (resolved at runtime).
  * Pass an empty string `""` to use the app name, or provide a custom title.
  *
- * **Notification text**: defaults to "Encontrando promoções".
+ * **Notification text**: defaults to "Scanning for nearby content".
  * This text is shown when the service starts. Once beacons are detected,
  * the SDK calls [BeAroundSDKListener.onProvideNotificationContent] so the host
- * app can return contextual text (e.g., "Ofertas disponíveis perto de você!").
+ * app can return contextual text (e.g., "Offers available nearby!").
  *
  * Examples of creative notification messages:
- * - "Buscando ofertas na sua região"
- * - "Descobrindo novidades por perto"
- * - "Conectando você a experiências próximas"
- * - "Rastreando promoções exclusivas"
+ * - "Looking for nearby deals"
+ * - "Discovering what's new around you"
+ * - "Connecting you to nearby experiences"
+ * - "Tracking exclusive offers in your area"
  */
 data class ForegroundScanConfig(
     val enabled: Boolean = false,
     /** Notification title. Empty string = app name (default). */
     val notificationTitle: String = "",
     /** Notification body text shown while scanning in background. */
-    val notificationText: String = "Encontrando promoções",
+    val notificationText: String = "Scanning for nearby content",
     val notificationIcon: Int? = null,
     val notificationChannelId: String? = null,
-    val notificationChannelName: String = "Serviço de monitoramento da região"
+    val notificationChannelName: String = "Region monitoring service"
 )

--- a/sdk/src/main/java/io/bearound/sdk/models/NotificationContent.kt
+++ b/sdk/src/main/java/io/bearound/sdk/models/NotificationContent.kt
@@ -8,11 +8,11 @@ package io.bearound.sdk.models
  * Use this to show contextual, user-friendly messages instead of
  * a generic "scanning" text. Be creative! Examples:
  *
- * - title = "Loja ABC"          , text = "Ofertas exclusivas esperando por você!"
- * - title = "Shopping Center"   , text = "Descubra promoções neste andar"
- * - title = "Evento XYZ"        , text = "Bem-vindo! Confira a programação"
- * - title = "Farmácia Popular"  , text = "Descontos especiais perto de você"
- * - title = "Restaurante Sabor" , text = "Cardápio do dia disponível!"
+ * - title = "Store ABC"           , text = "Exclusive offers waiting for you!"
+ * - title = "Shopping Center"     , text = "Discover deals on this floor"
+ * - title = "Event XYZ"           , text = "Welcome! Check the schedule"
+ * - title = "Local Pharmacy"      , text = "Special discounts nearby"
+ * - title = "Restaurant Flavor"   , text = "Today's menu is ready!"
  *
  * Return `null` from [onProvideNotificationContent] to keep the default
  * text defined in [ForegroundScanConfig].
@@ -20,6 +20,6 @@ package io.bearound.sdk.models
 data class NotificationContent(
     /** Notification title — e.g., the app or location name. */
     val title: String,
-    /** Notification body — e.g., "Encontramos promoções para você!" */
+    /** Notification body — e.g., "We found offers for you!" */
     val text: String
 )

--- a/sdk/src/main/java/io/bearound/sdk/utilities/SDKConfigStorage.kt
+++ b/sdk/src/main/java/io/bearound/sdk/utilities/SDKConfigStorage.kt
@@ -153,11 +153,11 @@ object SDKConfigStorage {
 
         return ForegroundScanConfig(
             enabled = prefs.getBoolean(KEY_FG_SCAN_ENABLED, false),
-            notificationTitle = prefs.getString(KEY_FG_SCAN_TITLE, "Monitorando região") ?: "Monitorando região",
-            notificationText = prefs.getString(KEY_FG_SCAN_TEXT, "Verificando região em background") ?: "Verificando região em background",
+            notificationTitle = prefs.getString(KEY_FG_SCAN_TITLE, "Monitoring region") ?: "Monitoring region",
+            notificationText = prefs.getString(KEY_FG_SCAN_TEXT, "Checking region in background") ?: "Checking region in background",
             notificationIcon = icon,
             notificationChannelId = prefs.getString(KEY_FG_SCAN_CHANNEL_ID, null),
-            notificationChannelName = prefs.getString(KEY_FG_SCAN_CHANNEL_NAME, "Serviço de monitoramento da região") ?: "Serviço de monitoramento da região"
+            notificationChannelName = prefs.getString(KEY_FG_SCAN_CHANNEL_NAME, "Region monitoring service") ?: "Region monitoring service"
         )
     }
 }


### PR DESCRIPTION
## Summary

- Documents the hybrid two-eye wake-up model (mirrors iOS SDK v3.0.0).
- Explicit table of what each path (PendingIntent BLE scan vs. CoreLocation-equivalent) survives across system kill, user swipe, force-stop, and reboot.
- OEM caveat section covering Samsung "Sleeping apps", Xiaomi/Huawei/OnePlus killers, with the standard `REQUEST_IGNORE_BATTERY_OPTIMIZATIONS` mitigation.
- Translates all user-facing SDK default strings to English (foreground service notification title/text/channel, `ForegroundScanConfig` defaults, `SDKConfigStorage` fallbacks). Localized resources in `values-pt` / `values-es` are intentionally untouched — those are i18n resources, not docs.
- Translates `CHANGES.md` (BEAD Service Data migration notes) and the remaining KDoc examples to English.

## Empirical validation

Tested live on Samsung Galaxy A55 (Android 16, One UI):

1. Granted `BLUETOOTH_SCAN` only — Location explicitly denied.
2. `adb shell am force-stop io.bearound.bearoundscan` (process gone, `pidof` empty).
3. Inside beacon zone, kernel `PendingIntent` continued waking the app:

```
20:56:41 D BeAroundSDK         Processing 1 broadcast results (app in foreground: false)
20:56:41 D BeAroundSDK-BeaconM Processing external scan result from Bluetooth Broadcast
20:56:41 D BeAroundSDK-APIClient Sending 5 beacon(s) to https://ingest.bearound.io/ingest
20:56:42 D BeAroundSDK-APIClient Successfully sent 5 beacon(s)
```

This proves the SDK already delivers what the iOS SDK only delivers when the host app opts into the Location eye — and without requiring any Location permission on Android.

## Test plan

- [ ] Read the new "Terminated App Detection" section in README; confirm the wording matches the actual behavior on stock Pixel and Samsung.
- [ ] Smoke-build the SDK (`./gradlew :sdk:assembleRelease`) — confirms the translated strings compile.
- [ ] Optional: install `:BearoundScan:installDebug` on a device, grant only `BLUETOOTH_SCAN`, start scanning, force-stop, walk through a beacon zone, watch `adb logcat -v time --regex="BeAroundSDK|BluetoothScanReceiver"` for `Sending N beacon(s)` lines.

## Follow-ups (NOT in this PR)

- `app/README.md` and `BeaconNotifManager` cooldown log lines remain in Portuguese — separate clean-up.
- Future code change candidate: explicit `PendingIntent` re-registration in the `BOOT_COMPLETED` handler if config exists (currently relies on `wasScanningEnabled` flag).
