### PR TITLE
bump: version 3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.0] - 2026-05-27
+
+Mirrors the iOS SDK v3.0.0 hybrid wake-up model. This is a **major release** because the public Bluetooth permission surface changes (`BLUETOOTH_CONNECT` is no longer requested by the SDK manifest) and the default user-facing strings are now in English. Both are observable in production and require host-app awareness.
+
+### ⚠️ Breaking Changes
+
+- **`BLUETOOTH_CONNECT` is no longer declared by the SDK manifest.** The SDK only needs `BLUETOOTH_SCAN` (with `usesPermissionFlags="neverForLocation"`) to detect beacons. Host apps that previously relied on the SDK to pull in `BLUETOOTH_CONNECT` must add it to their own manifest if they use it for unrelated purposes — the SDK itself no longer requests it.
+- **Default user-facing strings shipped by the SDK are now English.** Foreground service notification title/text/channel name, `ForegroundScanConfig` defaults, and `SDKConfigStorage` fallbacks were Portuguese. Host apps that override these via `ForegroundScanConfig` / `NotificationContent` are unaffected. Apps that relied on the Portuguese defaults must override to keep the previous copy. Localized resources under `values-pt` / `values-es` are unchanged.
+
+### Added
+
+- **Hybrid wake-up architecture (parity with iOS SDK 3.0.0).** Documented end-to-end in README under "Terminated App Detection": kernel-registered `PendingIntent` BLE scan + `ScanWatchdogReceiver` + optional `BeaconScanService` foreground service. Force-stop and swipe-from-recents now survive on Android 14+ without any host-side code change.
+- **`Beacon.Proximity.BT` detection surface.** `BluetoothManager` callbacks now build a `Beacon` and emit it through `BeAroundSDKListener.onBeaconsUpdated`/`onBeaconDetectedInBackground` even when `BeaconManager` is not actively ranging. This is the foundation for the "always-on background detection" promise.
+- **OEM caveat matrix** in README — explicit guidance for Samsung One UI 6+, Xiaomi MIUI/HyperOS, Huawei/Honor EMUI/HarmonyOS and OnePlus OxygenOS, including the `REQUEST_IGNORE_BATTERY_OPTIMIZATIONS` mitigation.
+
+### Changed
+
+- **`AndroidManifest.xml` (SDK):** `BLUETOOTH_SCAN` now ships with `android:usesPermissionFlags="neverForLocation"`. Apps that need beacon scanning without Location authorization on Android 12+ benefit automatically.
+- **Default SDK copy is English.** Foreground service notification title ("Scanning beacons"), text, channel name, `ForegroundScanConfig` defaults, and `SDKConfigStorage` fallback strings are now English.
+- **`CHANGES.md` and remaining KDoc examples** translated to English.
+
+### Notes for integrators
+
+- If your manifest already declares `BLUETOOTH_CONNECT` for your own reasons (e.g. GATT writes), keep it. The SDK no longer pulls it in transitively, that's all.
+- If you were depending on Portuguese default notification copy, switch to passing a `ForegroundScanConfig(notification = NotificationContent(...))` with your localized strings.
+- No code changes required for the hybrid wake-up improvements — they apply automatically to existing integrations.
+
 ## [2.4.0] - 2026-05-22
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 
 Kotlin SDK for Android — secure BLE beacon detection and indoor positioning by BeAround.
 
-## Version 2.3.7
+## Version 3.0.0
 
-Latest version with precision-based scanning, duty-cycle architecture, foreground service support, and simplified API. Automatic Bluetooth scanning, smart periodic scanning based on app state, WorkManager integration, and AlarmManager watchdog.
+Hybrid wake-up parity with iOS SDK 3.0.0: kernel-registered `PendingIntent` BLE scan survives force-stop and swipe-from-recents on Android 14+ without a foreground service. `BLUETOOTH_SCAN` is declared with `neverForLocation`, so beacon detection no longer implies Location authorization. Default SDK user-facing strings are now English; precision-based scanning, duty-cycle architecture, foreground service support, and beacon-gated GPS from 2.4.0 are preserved.
 
 ## Features
 
@@ -63,7 +63,7 @@ dependencyResolutionManagement {
 
 ```gradle
 dependencies {
-    implementation 'com.github.Bearound:bearound-android-sdk:v2.3.7'
+    implementation 'com.github.Bearound:bearound-android-sdk:v3.0.0'
 }
 ```
 
@@ -84,8 +84,11 @@ Add these permissions to your `AndroidManifest.xml`:
 <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" android:maxSdkVersion="30" />
 
 <!-- Bluetooth (Android 12+) -->
-<uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
-<uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+<!-- BLUETOOTH_CONNECT is NOT required by the SDK as of v3.0.0.
+     Declare it only if your own app uses GATT operations. -->
+<uses-permission android:name="android.permission.BLUETOOTH_SCAN"
+    android:usesPermissionFlags="neverForLocation"
+    tools:targetApi="s" />
 
 <!-- Location -->
 <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
@@ -159,8 +162,9 @@ private fun requestPermissions() {
     )
     
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+        // Only BLUETOOTH_SCAN is required by the SDK (v3.0.0+).
+        // Declared with neverForLocation, so it does not imply Location authorization.
         permissions.add(Manifest.permission.BLUETOOTH_SCAN)
-        permissions.add(Manifest.permission.BLUETOOTH_CONNECT)
     }
     
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
@@ -594,8 +598,8 @@ Version 2.0.x introduces breaking changes. Follow these steps to migrate:
 // OLD (v1.x)
 implementation 'com.github.Bearound:bearound-android-sdk:1.3.2'
 
-// NEW (v2.3+)
-implementation 'com.github.Bearound:bearound-android-sdk:v2.3.7'
+// NEW (v3.0+)
+implementation 'com.github.Bearound:bearound-android-sdk:v3.0.0'
 ```
 
 ### 2. Update AndroidManifest.xml
@@ -735,7 +739,22 @@ Due to Android system restrictions and manufacturer-specific behaviors, the foll
 
 See [CHANGELOG.md](CHANGELOG.md) for detailed version history.
 
-### Version 2.3.7 (Latest)
+### Version 3.0.0 (Latest)
+
+- 🆕 **Hybrid wake-up parity with iOS SDK 3.0.0**: kernel-registered `PendingIntent` BLE scan survives force-stop and swipe-from-recents on Android 14+ without a foreground service
+- 🆕 **`BLUETOOTH_SCAN` with `neverForLocation`**: beacon detection no longer implies Location authorization on Android 12+
+- 🆕 **Surface BT detections via listener**: `BluetoothManager` now feeds `onBeaconsUpdated` / `onBeaconDetectedInBackground` even when the SDK is not actively ranging, with `Beacon.Proximity.BT`
+- 🆕 **OEM caveat matrix** in README (Samsung, Xiaomi, Huawei, OnePlus) + `REQUEST_IGNORE_BATTERY_OPTIMIZATIONS` mitigation
+- ⚠️ **Breaking**: SDK manifest no longer declares `BLUETOOTH_CONNECT` — host apps that need it must declare it themselves
+- ⚠️ **Breaking**: default user-facing SDK strings (foreground service notification, `ForegroundScanConfig`, `SDKConfigStorage` fallbacks) are now English — override via `ForegroundScanConfig`/`NotificationContent` if you need a specific locale
+
+### Version 2.4.0 (2026-05-22)
+
+- 🆕 **Beacon-gated GPS + active BLE scan**: only run while inside a beacon region (kernel filter scan stays on, ~0 battery outside)
+- 🆕 **Listener surface**: `onEnterBeaconRegion`, `onExitBeaconRegion`, `onActiveScanStateChanged`, `onStartLocationCapture`, `onCompleteLocationCapture`
+- 🆕 **`LocationCaptureResult` public model** + `BeaconManager.isInBeaconRegion`
+
+### Version 2.3.7 (2026-02-26)
 
 - 🆕 **Scan Precision**: Replaced `foregroundScanInterval`/`backgroundScanInterval` with `ScanPrecision` enum (HIGH, MEDIUM, LOW)
 - 🆕 **Duty Cycle Architecture**: Scan/pause cycle model for battery-efficient scanning

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,4 +11,4 @@ org.gradle.configureondemand=true
 # SDK Metadata
 SDK_GROUP_ID=com.github.Bearound
 SDK_ARTIFACT_ID=bearound-android-sdk
-SDK_VERSION=2.4.0
+SDK_VERSION=3.0.0


### PR DESCRIPTION
## Summary

Bumps the SDK to **3.0.0**, matching iOS SDK v3.0.0 that PR #45 mentioned but never reflected in the version files.

- `gradle.properties`: `SDK_VERSION` 2.4.0 → **3.0.0**
- `CHANGELOG.md`: new `[3.0.0]` section documenting hybrid wake-up parity, `BLUETOOTH_SCAN` `neverForLocation`, English defaults, and the listener surface change for BT detections
- `README.md`: header line, install snippets (lines 66 + 598), permission block (drops `BLUETOOTH_CONNECT`, adds `neverForLocation`), Kotlin permission-request example, and changelog section (adds 3.0.0 + backfills 2.4.0)

## Why a major bump

Two observable, host-visible changes since 2.4.0:

1. **Permission surface shrinks.** The SDK manifest no longer declares `BLUETOOTH_CONNECT` — only `BLUETOOTH_SCAN` with `android:usesPermissionFlags="neverForLocation"`. Hosts that transitively relied on the SDK to pull in `BLUETOOTH_CONNECT` for their own GATT writes must now declare it themselves.
2. **Default user-facing strings are now English** (foreground service notification title/text/channel, `ForegroundScanConfig` defaults, `SDKConfigStorage` fallbacks). Hosts that depended on the previous Portuguese defaults must override via `ForegroundScanConfig(notification = NotificationContent(...))`.

Either one alone justifies a major; together it's unambiguous. SemVer keeps drifting from iOS otherwise.

## Validation

- `./gradlew :sdk:assembleRelease` — BUILD SUCCESSFUL in 10s, no errors (only pre-existing Kotlin/Java deprecation warnings in `DeviceInfoCollector.kt`).
- `BuildConfig.SDK_VERSION` will now resolve to `"3.0.0"` for any host integrator.

## Test plan

- [ ] Smoke-build the SDK (`./gradlew :sdk:assembleRelease`) — already green locally.
- [ ] After merge: tag `v3.0.0` and let JitPack pick it up.
- [ ] Verify on a fresh consumer: `implementation 'com.github.Bearound:bearound-android-sdk:v3.0.0'` resolves and `BuildConfig.SDK_VERSION == "3.0.0"`.
- [ ] Confirm a host app that only declared `BLUETOOTH_SCAN` (no `BLUETOOTH_CONNECT`) still scans on Android 12+ — this is the regression the manifest change is meant to enable.

## Follow-ups (NOT in this PR)

- `app/README.md` cleanup (still partly Portuguese) — separate doc PR.
- Consider deprecating any remaining Portuguese-only resource fallbacks in `values-pt` if they no longer match the English defaults semantically.
