### PR TITLE
fix: faster background detection (SCAN_MODE_BALANCED)

### DIFF
--- a/sdk/src/main/java/io/bearound/sdk/BeaconManager.kt
+++ b/sdk/src/main/java/io/bearound/sdk/BeaconManager.kt
@@ -232,8 +232,9 @@ class BeaconManager(private val context: Context) {
                 .build()
         )
 
+        // Foreground service is active -> BALANCED (not LOW_POWER) for faster detection; Android throttles anyway without a FG service.
         val scanMode = if (isInForeground) ScanSettings.SCAN_MODE_LOW_LATENCY
-                       else ScanSettings.SCAN_MODE_LOW_POWER
+                       else ScanSettings.SCAN_MODE_BALANCED
 
         val settings = ScanSettings.Builder()
             .setScanMode(scanMode)

--- a/sdk/src/main/java/io/bearound/sdk/BluetoothManager.kt
+++ b/sdk/src/main/java/io/bearound/sdk/BluetoothManager.kt
@@ -76,7 +76,8 @@ class BluetoothManager(private val context: Context) {
 
         try {
             val settings = ScanSettings.Builder()
-                .setScanMode(ScanSettings.SCAN_MODE_LOW_POWER)
+                // Foreground service is active -> BALANCED (not LOW_POWER) for faster detection; Android throttles anyway without a FG service.
+                .setScanMode(ScanSettings.SCAN_MODE_BALANCED)
                 .setReportDelay(0)
                 .build()
 
@@ -130,7 +131,8 @@ class BluetoothManager(private val context: Context) {
         if (!checkPermissions()) return
         try {
             val settings = ScanSettings.Builder()
-                .setScanMode(ScanSettings.SCAN_MODE_LOW_POWER)
+                // Foreground service is active -> BALANCED (not LOW_POWER) for faster detection; Android throttles anyway without a FG service.
+                .setScanMode(ScanSettings.SCAN_MODE_BALANCED)
                 .setReportDelay(0)
                 .build()
             bluetoothLeScanner?.startScan(null, settings, scanCallback)

--- a/sdk/src/main/java/io/bearound/sdk/background/BackgroundScanManager.kt
+++ b/sdk/src/main/java/io/bearound/sdk/background/BackgroundScanManager.kt
@@ -100,7 +100,8 @@ class BackgroundScanManager(private val context: Context) {
             )
             
             val settings = ScanSettings.Builder()
-                .setScanMode(ScanSettings.SCAN_MODE_LOW_POWER)
+                // Foreground service is active -> BALANCED (not LOW_POWER) for faster detection; Android throttles anyway without a FG service.
+                .setScanMode(ScanSettings.SCAN_MODE_BALANCED)
                 .setCallbackType(ScanSettings.CALLBACK_TYPE_ALL_MATCHES)
                 .setMatchMode(ScanSettings.MATCH_MODE_AGGRESSIVE)
                 .setNumOfMatches(ScanSettings.MATCH_NUM_MAX_ADVERTISEMENT)


### PR DESCRIPTION
Background BLE scans ran in SCAN_MODE_LOW_POWER (~10% duty cycle → 15-50s to
detect). The SDK runs a foreground service (exempt from background-scan
throttling), so switch those scans to SCAN_MODE_BALANCED for much faster
detection. The foreground LOW_LATENCY path is unchanged; Android throttles a
higher mode anyway when there is no foreground service, so this is safe.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
