### PR TITLE
feat: Android SDK — FCM auto-collect + diagnostics + TTL + faster detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,6 +449,14 @@ val isForegroundScanningEnabled: Boolean = sdk.isForegroundScanningEnabled
 val pendingBatchCount: Int = sdk.pendingBatchCount
 ```
 
+### Push Notifications (FCM)
+
+If your app ships Firebase, `configure(...)` auto-collects the FCM token and sends it on the next sync. Firebase is a soft dependency (`compileOnly`): apps without it are unaffected. If you don't use Firebase, provide the token yourself:
+
+```kotlin
+sdk.setPushToken(token)
+```
+
 ### BeAroundSDKListener
 
 Implement this interface to receive SDK events:

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -37,6 +37,11 @@ android {
     kotlinOptions {
         jvmTarget = '11'
     }
+    testOptions {
+        unitTests {
+            includeAndroidResources = true
+        }
+    }
     publishing {
         singleVariant("release") {
             withSourcesJar()
@@ -118,6 +123,10 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.7.1'
     implementation 'com.google.android.material:material:1.12.0'
     testImplementation 'junit:junit:4.13.2'
+    // Robolectric provides an Android runtime for JVM unit tests (PushTokenStore needs a
+    // Context for EncryptedSharedPreferences via SecureStorage).
+    testImplementation 'org.robolectric:robolectric:4.13'
+    testImplementation 'androidx.test:core:1.6.1'
     androidTestImplementation 'androidx.test.ext:junit:1.2.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
 

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -145,4 +145,8 @@ dependencies {
     
     // Gson for JSON serialization (offline batch storage)
     implementation 'com.google.code.gson:gson:2.13.2'
+
+    // Firebase Cloud Messaging — soft dependency (compileOnly, not bundled). See tryAutoCollectFcmToken.
+    compileOnly 'com.google.firebase:firebase-messaging:24.0.0'
+    compileOnly 'com.google.firebase:firebase-common:21.0.0'
 }

--- a/sdk/consumer-rules.pro
+++ b/sdk/consumer-rules.pro
@@ -1,1 +1,5 @@
 -keep class io.bearound.sdk.** { public *; }
+
+# firebase-messaging is compileOnly (optional) — ignore its absent classes in R8
+-dontwarn com.google.firebase.**
+-dontwarn com.google.android.gms.**

--- a/sdk/proguard-rules.pro
+++ b/sdk/proguard-rules.pro
@@ -31,3 +31,7 @@
 -keep public interface io.bearound.sdk.** {
     public *;
 }
+
+# firebase-messaging is compileOnly (optional) — ignore its absent classes in R8
+-dontwarn com.google.firebase.**
+-dontwarn com.google.android.gms.**

--- a/sdk/src/main/java/io/bearound/sdk/BeAroundSDK.kt
+++ b/sdk/src/main/java/io/bearound/sdk/BeAroundSDK.kt
@@ -345,6 +345,7 @@ class BeAroundSDK private constructor() {
         listener?.onAppStateChanged(isInBackground = true)
     }
 
+    /** Configures and activates the SDK. Auto-collects the FCM token if Firebase is present (see [tryAutoCollectFcmToken]). */
     fun configure(
         businessToken: String,
         scanPrecision: ScanPrecision = ScanPrecision.MEDIUM,
@@ -379,8 +380,27 @@ class BeAroundSDK private constructor() {
 
         SDKConfigStorage.saveConfiguration(context, config)
 
+        tryAutoCollectFcmToken(context)
+
         if (isScanning) {
             startSyncTimer()
+        }
+    }
+
+    /** Best-effort FCM token fetch. Firebase is compileOnly, so guard against it being absent at runtime; falls back to [setPushToken]. */
+    private fun tryAutoCollectFcmToken(context: Context) {
+        try {
+            if (com.google.firebase.FirebaseApp.getApps(context).isEmpty()) return
+            com.google.firebase.messaging.FirebaseMessaging.getInstance().token
+                .addOnSuccessListener { token ->
+                    if (!token.isNullOrEmpty()) {
+                        PushTokenStore.setToken(token)
+                        Log.i(TAG, "FCM token auto-collected")
+                    }
+                }
+                .addOnFailureListener { e -> Log.w(TAG, "FCM token fetch failed: ${e.message}") }
+        } catch (t: Throwable) {
+            Log.i(TAG, "Firebase not available; client must call setPushToken() to provide the FCM token")
         }
     }
 

--- a/sdk/src/main/java/io/bearound/sdk/BeAroundSDK.kt
+++ b/sdk/src/main/java/io/bearound/sdk/BeAroundSDK.kt
@@ -20,6 +20,7 @@ import io.bearound.sdk.background.BeaconScanService
 import io.bearound.sdk.interfaces.BeAroundSDKListener
 import io.bearound.sdk.interfaces.BluetoothManagerListener
 import io.bearound.sdk.models.Beacon
+import io.bearound.sdk.models.BeAroundDiagnostics
 import io.bearound.sdk.models.BeaconMetadata
 import io.bearound.sdk.models.ForegroundScanConfig
 import io.bearound.sdk.models.MaxQueuedPayloads
@@ -28,7 +29,9 @@ import io.bearound.sdk.models.SDKInfo
 import io.bearound.sdk.models.ScanPrecision
 import io.bearound.sdk.models.UserProperties
 import io.bearound.sdk.network.APIClient
+import io.bearound.sdk.utilities.DeviceIdentifier
 import io.bearound.sdk.utilities.DeviceInfoCollector
+import io.bearound.sdk.utilities.DiagnosticsStore
 import io.bearound.sdk.utilities.OfflineBatchStorage
 import io.bearound.sdk.utilities.PushTokenStore
 import io.bearound.sdk.utilities.SDKConfigStorage
@@ -735,6 +738,9 @@ class BeAroundSDK private constructor() {
                 if (stats != b.rssiSamples) b.copy(rssiSamples = stats) else b
             }
 
+            // Record the scan result (beacons collected from scanning this window).
+            DiagnosticsStore.recordScan(beaconsToSend.size)
+
             isSyncing = true
 
             // Notify listener that sync is starting
@@ -793,7 +799,8 @@ class BeAroundSDK private constructor() {
                         }, 30_000L)
 
                         // Notify listener of success
-                        PushTokenStore.markSynced()
+                        PushTokenStore.markSent()
+                        DiagnosticsStore.recordSync(success = true, beaconCount = beaconsToSend.size)
                         handler.post {
                             listener?.onSyncCompleted(beaconsToSend.size, success = true, error = null)
                         }
@@ -801,6 +808,8 @@ class BeAroundSDK private constructor() {
                     onFailure = { error ->
                         Log.e(TAG, "Sync failed: ${error.message}")
                         handleSyncFailure(beaconsToSend, error, isRetry = false)
+
+                        DiagnosticsStore.recordSync(success = false, beaconCount = beaconsToSend.size)
 
                         // Notify listener of failure
                         handler.post {
@@ -863,6 +872,9 @@ class BeAroundSDK private constructor() {
                 consecutiveFailures++
                 lastFailureTime = System.currentTimeMillis()
 
+                DiagnosticsStore.recordSync(success = false, beaconCount = beaconsInChunk.size)
+                DiagnosticsStore.recordError("Retry chunk failed: ${error.message}")
+
                 handler.post {
                     listener?.onSyncCompleted(
                         beaconsInChunk.size,
@@ -885,7 +897,8 @@ class BeAroundSDK private constructor() {
 
             Log.d(TAG, "Retry chunk ${chunkIndex + 1}/${chunks.size} succeeded — removed ${chunk.size} batch(es)")
 
-            PushTokenStore.markSynced()
+            PushTokenStore.markSent()
+            DiagnosticsStore.recordSync(success = true, beaconCount = beaconsInChunk.size)
             handler.post {
                 listener?.onSyncCompleted(beaconsInChunk.size, success = true, error = null)
             }
@@ -898,6 +911,8 @@ class BeAroundSDK private constructor() {
     private fun handleSyncFailure(beacons: List<Beacon>, error: Throwable, isRetry: Boolean) {
         consecutiveFailures++
         lastFailureTime = System.currentTimeMillis()
+
+        DiagnosticsStore.recordError("Sync failed: ${error.message}")
 
         // Save to persistent storage (only if not already a retry)
         if (!isRetry) {
@@ -964,7 +979,31 @@ class BeAroundSDK private constructor() {
      */
     val pendingBatches: List<List<Beacon>>
         get() = offlineBatchStorage.loadAllBatches()
-    
+
+    /**
+     * Returns a point-in-time snapshot of SDK state for diagnostics/support.
+     *
+     * Combines persisted identity and push-token state with in-memory activity from
+     * [DiagnosticsStore] (recent scan/sync outcomes and errors). Safe to call at any
+     * time; values are best-effort and reflect what the SDK has observed so far.
+     */
+    fun diagnostics(): BeAroundDiagnostics {
+        return BeAroundDiagnostics(
+            deviceId = DeviceIdentifier.getDeviceId(context),
+            pushTokenMasked = PushTokenStore.maskedToken(),
+            pushTokenLastSentAt = PushTokenStore.lastSentAt(),
+            isScanning = isScanning,
+            pendingBatches = pendingBatchCount,
+            lastScanAt = DiagnosticsStore.lastScanAt(),
+            lastScanBeaconCount = DiagnosticsStore.lastScanBeaconCount(),
+            lastSyncAt = DiagnosticsStore.lastSyncAt(),
+            lastSyncSuccess = DiagnosticsStore.lastSyncSuccess(),
+            lastSyncBeaconCount = DiagnosticsStore.lastSyncBeaconCount(),
+            recentErrors = DiagnosticsStore.recentErrors(),
+            sdkVersion = Build.VERSION.SDK_INT
+        )
+    }
+
     /**
      * Perform background sync
      * Called by WorkManager and AlarmManager watchdog

--- a/sdk/src/main/java/io/bearound/sdk/BeaconManager.kt
+++ b/sdk/src/main/java/io/bearound/sdk/BeaconManager.kt
@@ -232,8 +232,9 @@ class BeaconManager(private val context: Context) {
                 .build()
         )
 
+        // Foreground service is active -> BALANCED (not LOW_POWER) for faster detection; Android throttles anyway without a FG service.
         val scanMode = if (isInForeground) ScanSettings.SCAN_MODE_LOW_LATENCY
-                       else ScanSettings.SCAN_MODE_LOW_POWER
+                       else ScanSettings.SCAN_MODE_BALANCED
 
         val settings = ScanSettings.Builder()
             .setScanMode(scanMode)

--- a/sdk/src/main/java/io/bearound/sdk/BluetoothManager.kt
+++ b/sdk/src/main/java/io/bearound/sdk/BluetoothManager.kt
@@ -76,7 +76,8 @@ class BluetoothManager(private val context: Context) {
 
         try {
             val settings = ScanSettings.Builder()
-                .setScanMode(ScanSettings.SCAN_MODE_LOW_POWER)
+                // Foreground service is active -> BALANCED (not LOW_POWER) for faster detection; Android throttles anyway without a FG service.
+                .setScanMode(ScanSettings.SCAN_MODE_BALANCED)
                 .setReportDelay(0)
                 .build()
 
@@ -130,7 +131,8 @@ class BluetoothManager(private val context: Context) {
         if (!checkPermissions()) return
         try {
             val settings = ScanSettings.Builder()
-                .setScanMode(ScanSettings.SCAN_MODE_LOW_POWER)
+                // Foreground service is active -> BALANCED (not LOW_POWER) for faster detection; Android throttles anyway without a FG service.
+                .setScanMode(ScanSettings.SCAN_MODE_BALANCED)
                 .setReportDelay(0)
                 .build()
             bluetoothLeScanner?.startScan(null, settings, scanCallback)

--- a/sdk/src/main/java/io/bearound/sdk/background/BackgroundScanManager.kt
+++ b/sdk/src/main/java/io/bearound/sdk/background/BackgroundScanManager.kt
@@ -100,7 +100,8 @@ class BackgroundScanManager(private val context: Context) {
             )
             
             val settings = ScanSettings.Builder()
-                .setScanMode(ScanSettings.SCAN_MODE_LOW_POWER)
+                // Foreground service is active -> BALANCED (not LOW_POWER) for faster detection; Android throttles anyway without a FG service.
+                .setScanMode(ScanSettings.SCAN_MODE_BALANCED)
                 .setCallbackType(ScanSettings.CALLBACK_TYPE_ALL_MATCHES)
                 .setMatchMode(ScanSettings.MATCH_MODE_AGGRESSIVE)
                 .setNumOfMatches(ScanSettings.MATCH_NUM_MAX_ADVERTISEMENT)

--- a/sdk/src/main/java/io/bearound/sdk/models/BeAroundDiagnostics.kt
+++ b/sdk/src/main/java/io/bearound/sdk/models/BeAroundDiagnostics.kt
@@ -1,18 +1,6 @@
 package io.bearound.sdk.models
 
-/**
- * Point-in-time snapshot of SDK state, produced by `BeAroundSDK.diagnostics()`.
- *
- * Lets integrators and support inspect what the SDK is doing — scanning state, the
- * masked push token and when it was last delivered, pending upload backlog, and the
- * most recent scan/sync outcomes — without pulling files off the device.
- *
- * @property pushTokenMasked current push token masked for display, or null when unset.
- * @property pushTokenLastSentAt epoch millis of the last successful token send, or null.
- * @property pendingBatches number of failed batches awaiting retry.
- * @property recentErrors most recent errors, oldest first, each "<epochMillis> | <message>".
- * @property sdkVersion the Android OS API level the SDK is running on (Build.VERSION.SDK_INT).
- */
+/** Point-in-time snapshot of SDK state, produced by `BeAroundSDK.diagnostics()`. */
 data class BeAroundDiagnostics(
     val deviceId: String,
     val pushTokenMasked: String?,
@@ -27,9 +15,6 @@ data class BeAroundDiagnostics(
     val recentErrors: List<String>,
     val sdkVersion: Int
 ) {
-    /**
-     * Readable multi-line rendering of the snapshot, suitable for logs or a support ticket.
-     */
     fun summary(): String {
         val errorsBlock = if (recentErrors.isEmpty()) {
             "  (none)"

--- a/sdk/src/main/java/io/bearound/sdk/models/BeAroundDiagnostics.kt
+++ b/sdk/src/main/java/io/bearound/sdk/models/BeAroundDiagnostics.kt
@@ -1,0 +1,57 @@
+package io.bearound.sdk.models
+
+/**
+ * Point-in-time snapshot of SDK state, produced by `BeAroundSDK.diagnostics()`.
+ *
+ * Lets integrators and support inspect what the SDK is doing — scanning state, the
+ * masked push token and when it was last delivered, pending upload backlog, and the
+ * most recent scan/sync outcomes — without pulling files off the device.
+ *
+ * @property pushTokenMasked current push token masked for display, or null when unset.
+ * @property pushTokenLastSentAt epoch millis of the last successful token send, or null.
+ * @property pendingBatches number of failed batches awaiting retry.
+ * @property recentErrors most recent errors, oldest first, each "<epochMillis> | <message>".
+ * @property sdkVersion the Android OS API level the SDK is running on (Build.VERSION.SDK_INT).
+ */
+data class BeAroundDiagnostics(
+    val deviceId: String,
+    val pushTokenMasked: String?,
+    val pushTokenLastSentAt: Long?,
+    val isScanning: Boolean,
+    val pendingBatches: Int,
+    val lastScanAt: Long?,
+    val lastScanBeaconCount: Int?,
+    val lastSyncAt: Long?,
+    val lastSyncSuccess: Boolean?,
+    val lastSyncBeaconCount: Int?,
+    val recentErrors: List<String>,
+    val sdkVersion: Int
+) {
+    /**
+     * Readable multi-line rendering of the snapshot, suitable for logs or a support ticket.
+     */
+    fun summary(): String {
+        val errorsBlock = if (recentErrors.isEmpty()) {
+            "  (none)"
+        } else {
+            recentErrors.joinToString("\n") { "  - $it" }
+        }
+
+        return buildString {
+            appendLine("BeAround Diagnostics")
+            appendLine("  deviceId: $deviceId")
+            appendLine("  sdkVersion (OS API): $sdkVersion")
+            appendLine("  isScanning: $isScanning")
+            appendLine("  pendingBatches: $pendingBatches")
+            appendLine("  pushTokenMasked: ${pushTokenMasked ?: "none"}")
+            appendLine("  pushTokenLastSentAt: ${pushTokenLastSentAt ?: "never"}")
+            appendLine("  lastScanAt: ${lastScanAt ?: "never"}")
+            appendLine("  lastScanBeaconCount: ${lastScanBeaconCount ?: "n/a"}")
+            appendLine("  lastSyncAt: ${lastSyncAt ?: "never"}")
+            appendLine("  lastSyncSuccess: ${lastSyncSuccess ?: "n/a"}")
+            appendLine("  lastSyncBeaconCount: ${lastSyncBeaconCount ?: "n/a"}")
+            appendLine("  recentErrors:")
+            append(errorsBlock)
+        }
+    }
+}

--- a/sdk/src/main/java/io/bearound/sdk/utilities/DeviceInfoCollector.kt
+++ b/sdk/src/main/java/io/bearound/sdk/utilities/DeviceInfoCollector.kt
@@ -37,7 +37,7 @@ class DeviceInfoCollector(
     ): UserDevice {
         return UserDevice(
             deviceId = DeviceIdentifier.getDeviceId(context),
-            pushToken = PushTokenStore.unsyncedToken(),
+            pushToken = PushTokenStore.tokenForPayload(),
             manufacturer = Build.MANUFACTURER,
             model = Build.MODEL,
             osVersion = Build.VERSION.RELEASE,

--- a/sdk/src/main/java/io/bearound/sdk/utilities/DiagnosticsStore.kt
+++ b/sdk/src/main/java/io/bearound/sdk/utilities/DiagnosticsStore.kt
@@ -1,12 +1,6 @@
 package io.bearound.sdk.utilities
 
-/**
- * In-memory, thread-safe store of recent SDK activity for observability.
- *
- * Holds the last scan/sync outcomes and a small ring buffer of recent errors so a
- * snapshot can be assembled (see [io.bearound.sdk.models.BeAroundDiagnostics]) without
- * pulling device files. State is process-lifetime only — it resets when the process dies.
- */
+/** In-memory, thread-safe store of recent SDK activity for diagnostics. Resets on process death. */
 object DiagnosticsStore {
     private const val MAX_ERRORS = 10
 
@@ -55,6 +49,5 @@ object DiagnosticsStore {
 
     fun lastScanBeaconCount(): Int? = synchronized(lock) { lastScanBeaconCount }
 
-    /** Returns a copy of the recent-errors ring buffer, oldest first. */
     fun recentErrors(): List<String> = synchronized(lock) { recentErrors.toList() }
 }

--- a/sdk/src/main/java/io/bearound/sdk/utilities/DiagnosticsStore.kt
+++ b/sdk/src/main/java/io/bearound/sdk/utilities/DiagnosticsStore.kt
@@ -1,0 +1,60 @@
+package io.bearound.sdk.utilities
+
+/**
+ * In-memory, thread-safe store of recent SDK activity for observability.
+ *
+ * Holds the last scan/sync outcomes and a small ring buffer of recent errors so a
+ * snapshot can be assembled (see [io.bearound.sdk.models.BeAroundDiagnostics]) without
+ * pulling device files. State is process-lifetime only — it resets when the process dies.
+ */
+object DiagnosticsStore {
+    private const val MAX_ERRORS = 10
+
+    private val lock = Any()
+
+    private var lastSyncAt: Long? = null
+    private var lastSyncSuccess: Boolean? = null
+    private var lastSyncBeaconCount: Int? = null
+
+    private var lastScanAt: Long? = null
+    private var lastScanBeaconCount: Int? = null
+
+    private val recentErrors = ArrayDeque<String>(MAX_ERRORS)
+
+    fun recordSync(success: Boolean, beaconCount: Int) {
+        synchronized(lock) {
+            lastSyncAt = System.currentTimeMillis()
+            lastSyncSuccess = success
+            lastSyncBeaconCount = beaconCount
+        }
+    }
+
+    fun recordScan(beaconCount: Int) {
+        synchronized(lock) {
+            lastScanAt = System.currentTimeMillis()
+            lastScanBeaconCount = beaconCount
+        }
+    }
+
+    fun recordError(msg: String) {
+        synchronized(lock) {
+            if (recentErrors.size >= MAX_ERRORS) {
+                recentErrors.removeFirst()
+            }
+            recentErrors.addLast("${System.currentTimeMillis()} | $msg")
+        }
+    }
+
+    fun lastSyncAt(): Long? = synchronized(lock) { lastSyncAt }
+
+    fun lastSyncSuccess(): Boolean? = synchronized(lock) { lastSyncSuccess }
+
+    fun lastSyncBeaconCount(): Int? = synchronized(lock) { lastSyncBeaconCount }
+
+    fun lastScanAt(): Long? = synchronized(lock) { lastScanAt }
+
+    fun lastScanBeaconCount(): Int? = synchronized(lock) { lastScanBeaconCount }
+
+    /** Returns a copy of the recent-errors ring buffer, oldest first. */
+    fun recentErrors(): List<String> = synchronized(lock) { recentErrors.toList() }
+}

--- a/sdk/src/main/java/io/bearound/sdk/utilities/PushTokenStore.kt
+++ b/sdk/src/main/java/io/bearound/sdk/utilities/PushTokenStore.kt
@@ -1,42 +1,74 @@
 package io.bearound.sdk.utilities
 
 /**
- * Stores the device's push token (FCM/APNs) and tracks whether it has been synced
- * to the backend. Backed by [SecureStorage]. The token is sent once with the next
- * request and re-sent only when it changes.
+ * Stores the device's push token (FCM/APNs) and tracks when it was last successfully
+ * sent to the backend. Backed by [SecureStorage].
+ *
+ * Delivery is heartbeat-based: the token is included in a payload when it changed
+ * since the last successful send OR when the last successful send is older than
+ * [RESEND_INTERVAL_MS]. This makes delivery resilient to a single lost send — the
+ * device stays reachable instead of becoming unpushable until the next rotation.
  */
 object PushTokenStore {
     private const val TOKEN_KEY = "io.bearound.sdk.pushToken"
-    private const val SYNCED_KEY = "io.bearound.sdk.pushTokenSynced"
+    private const val LAST_SENT_KEY = "io.bearound.sdk.pushTokenLastSent"
+    private const val LAST_SENT_AT_KEY = "io.bearound.sdk.pushTokenLastSentAt"
+
+    /** Re-send the token if the last successful send is older than 7 days. */
+    private const val RESEND_INTERVAL_MS = 604800000L
 
     /**
-     * Registers a push token. If it differs from the stored one, persists it and
-     * marks it as not yet synced. Idempotent when the token is unchanged.
+     * Stores the current push token. No send-state manipulation — delivery is decided
+     * by [tokenForPayload] based on what was last successfully sent.
      */
     fun setToken(token: String) {
-        if (token == SecureStorage.retrieve(TOKEN_KEY)) {
-            return
-        }
         SecureStorage.save(TOKEN_KEY, token)
-        SecureStorage.save(SYNCED_KEY, "false")
     }
 
     /**
-     * Returns the stored token only while it still needs to be synced; null otherwise.
+     * Returns the current token when it should be sent, otherwise null.
+     *
+     * It should be sent when there is a current token AND either it differs from the
+     * last successfully sent token, or it has never been sent, or the last send is
+     * older than [RESEND_INTERVAL_MS].
      */
-    fun unsyncedToken(): String? {
-        if (SecureStorage.retrieve(SYNCED_KEY) == "true") {
-            return null
-        }
-        return SecureStorage.retrieve(TOKEN_KEY)
+    fun tokenForPayload(): String? {
+        val token = SecureStorage.retrieve(TOKEN_KEY) ?: return null
+        val lastSent = SecureStorage.retrieve(LAST_SENT_KEY)
+        val lastSentAt = SecureStorage.retrieve(LAST_SENT_AT_KEY)?.toLongOrNull()
+
+        val shouldSend = token != lastSent ||
+            lastSentAt == null ||
+            (System.currentTimeMillis() - lastSentAt) > RESEND_INTERVAL_MS
+
+        return if (shouldSend) token else null
     }
 
     /**
-     * Marks the stored token as synced so it stops being included in requests.
+     * Records a successful send: remembers the token that was sent and the time.
      */
-    fun markSynced() {
-        if (SecureStorage.retrieve(TOKEN_KEY) != null) {
-            SecureStorage.save(SYNCED_KEY, "true")
+    fun markSent() {
+        val token = SecureStorage.retrieve(TOKEN_KEY) ?: return
+        SecureStorage.save(LAST_SENT_KEY, token)
+        SecureStorage.save(LAST_SENT_AT_KEY, System.currentTimeMillis().toString())
+    }
+
+    /**
+     * Epoch millis of the last successful send, or null if never sent.
+     */
+    fun lastSentAt(): Long? {
+        return SecureStorage.retrieve(LAST_SENT_AT_KEY)?.toLongOrNull()
+    }
+
+    /**
+     * The current token masked for display (first 8 + "…" + last 4), or null when
+     * there is no token. Short tokens are masked wholesale to avoid leaking them.
+     */
+    fun maskedToken(): String? {
+        val token = SecureStorage.retrieve(TOKEN_KEY) ?: return null
+        if (token.length <= 12) {
+            return "…"
         }
+        return "${token.take(8)}…${token.takeLast(4)}"
     }
 }

--- a/sdk/src/main/java/io/bearound/sdk/utilities/PushTokenStore.kt
+++ b/sdk/src/main/java/io/bearound/sdk/utilities/PushTokenStore.kt
@@ -1,14 +1,6 @@
 package io.bearound.sdk.utilities
 
-/**
- * Stores the device's push token (FCM/APNs) and tracks when it was last successfully
- * sent to the backend. Backed by [SecureStorage].
- *
- * Delivery is heartbeat-based: the token is included in a payload when it changed
- * since the last successful send OR when the last successful send is older than
- * [RESEND_INTERVAL_MS]. This makes delivery resilient to a single lost send — the
- * device stays reachable instead of becoming unpushable until the next rotation.
- */
+/** Stores the device's push token and heartbeat-resends it (see [tokenForPayload]). Backed by [SecureStorage]. */
 object PushTokenStore {
     private const val TOKEN_KEY = "io.bearound.sdk.pushToken"
     private const val LAST_SENT_KEY = "io.bearound.sdk.pushTokenLastSent"
@@ -17,21 +9,11 @@ object PushTokenStore {
     /** Re-send the token if the last successful send is older than 7 days. */
     private const val RESEND_INTERVAL_MS = 604800000L
 
-    /**
-     * Stores the current push token. No send-state manipulation — delivery is decided
-     * by [tokenForPayload] based on what was last successfully sent.
-     */
     fun setToken(token: String) {
         SecureStorage.save(TOKEN_KEY, token)
     }
 
-    /**
-     * Returns the current token when it should be sent, otherwise null.
-     *
-     * It should be sent when there is a current token AND either it differs from the
-     * last successfully sent token, or it has never been sent, or the last send is
-     * older than [RESEND_INTERVAL_MS].
-     */
+    /** Returns the current token when it should be sent (changed, never sent, or stale), else null. */
     fun tokenForPayload(): String? {
         val token = SecureStorage.retrieve(TOKEN_KEY) ?: return null
         val lastSent = SecureStorage.retrieve(LAST_SENT_KEY)
@@ -44,26 +26,17 @@ object PushTokenStore {
         return if (shouldSend) token else null
     }
 
-    /**
-     * Records a successful send: remembers the token that was sent and the time.
-     */
     fun markSent() {
         val token = SecureStorage.retrieve(TOKEN_KEY) ?: return
         SecureStorage.save(LAST_SENT_KEY, token)
         SecureStorage.save(LAST_SENT_AT_KEY, System.currentTimeMillis().toString())
     }
 
-    /**
-     * Epoch millis of the last successful send, or null if never sent.
-     */
     fun lastSentAt(): Long? {
         return SecureStorage.retrieve(LAST_SENT_AT_KEY)?.toLongOrNull()
     }
 
-    /**
-     * The current token masked for display (first 8 + "…" + last 4), or null when
-     * there is no token. Short tokens are masked wholesale to avoid leaking them.
-     */
+    /** Current token masked for display (first 8 + "…" + last 4), or null when unset. */
     fun maskedToken(): String? {
         val token = SecureStorage.retrieve(TOKEN_KEY) ?: return null
         if (token.length <= 12) {

--- a/sdk/src/test/java/io/bearound/sdk/models/BeAroundDiagnosticsTest.kt
+++ b/sdk/src/test/java/io/bearound/sdk/models/BeAroundDiagnosticsTest.kt
@@ -1,0 +1,70 @@
+package io.bearound.sdk.models
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pure JVM tests for [BeAroundDiagnostics.summary] — the human-readable rendering used
+ * in logs and support tickets.
+ */
+class BeAroundDiagnosticsTest {
+
+    private fun sample(
+        recentErrors: List<String> = emptyList(),
+        pushTokenMasked: String? = "abcd1234…wxyz",
+        pushTokenLastSentAt: Long? = 1_700_000_000_000L,
+    ) = BeAroundDiagnostics(
+        deviceId = "device-123",
+        pushTokenMasked = pushTokenMasked,
+        pushTokenLastSentAt = pushTokenLastSentAt,
+        isScanning = true,
+        pendingBatches = 4,
+        lastScanAt = 1_700_000_111_000L,
+        lastScanBeaconCount = 9,
+        lastSyncAt = 1_700_000_222_000L,
+        lastSyncSuccess = true,
+        lastSyncBeaconCount = 8,
+        recentErrors = recentErrors,
+        sdkVersion = 34,
+    )
+
+    @Test
+    fun `summary contains the key fields`() {
+        val text = sample().summary()
+
+        assertTrue("header present", text.contains("BeAround Diagnostics"))
+        assertTrue("deviceId present", text.contains("deviceId: device-123"))
+        assertTrue("masked token present", text.contains("pushTokenMasked: abcd1234…wxyz"))
+        assertTrue("pendingBatches present", text.contains("pendingBatches: 4"))
+        assertTrue("isScanning present", text.contains("isScanning: true"))
+        assertTrue("sdkVersion present", text.contains("sdkVersion (OS API): 34"))
+        assertTrue("lastSyncSuccess present", text.contains("lastSyncSuccess: true"))
+    }
+
+    @Test
+    fun `summary renders none for empty errors branch`() {
+        val text = sample(recentErrors = emptyList()).summary()
+
+        assertTrue("recentErrors header present", text.contains("recentErrors:"))
+        assertTrue("empty branch renders (none)", text.contains("(none)"))
+    }
+
+    @Test
+    fun `summary lists each error in the with-errors branch`() {
+        val errors = listOf("1700000000000 | first failure", "1700000005000 | second failure")
+        val text = sample(recentErrors = errors).summary()
+
+        assertTrue("must not show (none) when errors exist", !text.contains("(none)"))
+        errors.forEach { e ->
+            assertTrue("error line present: $e", text.contains("  - $e"))
+        }
+    }
+
+    @Test
+    fun `summary renders fallbacks when token and timestamp are absent`() {
+        val text = sample(pushTokenMasked = null, pushTokenLastSentAt = null).summary()
+
+        assertTrue("null token renders as none", text.contains("pushTokenMasked: none"))
+        assertTrue("null lastSentAt renders as never", text.contains("pushTokenLastSentAt: never"))
+    }
+}

--- a/sdk/src/test/java/io/bearound/sdk/utilities/DiagnosticsStoreTest.kt
+++ b/sdk/src/test/java/io/bearound/sdk/utilities/DiagnosticsStoreTest.kt
@@ -1,0 +1,140 @@
+package io.bearound.sdk.utilities
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Pure JVM tests for [DiagnosticsStore].
+ *
+ * [DiagnosticsStore] is a singleton `object` with mutable process-lifetime state and no
+ * public reset hook, so each test would otherwise inherit state from the previous one.
+ * [reset] drains every field via reflection in [setUp] so the tests are fully
+ * order-independent.
+ */
+class DiagnosticsStoreTest {
+
+    @Before
+    fun setUp() {
+        reset()
+    }
+
+    /** Resets all private state of the singleton to its initial (empty) values. */
+    private fun reset() {
+        val store = DiagnosticsStore
+        val cls = store.javaClass
+
+        listOf(
+            "lastSyncAt",
+            "lastSyncSuccess",
+            "lastSyncBeaconCount",
+            "lastScanAt",
+            "lastScanBeaconCount",
+        ).forEach { name ->
+            cls.getDeclaredField(name).apply {
+                isAccessible = true
+                set(store, null)
+            }
+        }
+
+        val errorsField = cls.getDeclaredField("recentErrors").apply { isAccessible = true }
+        val deque = errorsField.get(store) as ArrayDeque<*>
+        deque.clear()
+    }
+
+    @Test
+    fun `recordScan updates lastScanAt and beacon count`() {
+        val before = System.currentTimeMillis()
+        DiagnosticsStore.recordScan(beaconCount = 7)
+        val after = System.currentTimeMillis()
+
+        val at = DiagnosticsStore.lastScanAt()
+        assertTrue("lastScanAt should be set", at != null)
+        assertTrue("lastScanAt should be within the call window", at!! in before..after)
+        assertEquals(7, DiagnosticsStore.lastScanBeaconCount())
+    }
+
+    @Test
+    fun `recordSync updates success and beacon count`() {
+        val before = System.currentTimeMillis()
+        DiagnosticsStore.recordSync(success = true, beaconCount = 3)
+        val after = System.currentTimeMillis()
+
+        val at = DiagnosticsStore.lastSyncAt()
+        assertTrue("lastSyncAt should be set", at != null)
+        assertTrue("lastSyncAt should be within the call window", at!! in before..after)
+        assertEquals(true, DiagnosticsStore.lastSyncSuccess())
+        assertEquals(3, DiagnosticsStore.lastSyncBeaconCount())
+    }
+
+    @Test
+    fun `recordSync preserves failure outcome`() {
+        DiagnosticsStore.recordSync(success = false, beaconCount = 0)
+
+        assertEquals(false, DiagnosticsStore.lastSyncSuccess())
+        assertEquals(0, DiagnosticsStore.lastSyncBeaconCount())
+    }
+
+    @Test
+    fun `recordScan and recordSync do not bleed into each other`() {
+        DiagnosticsStore.recordScan(beaconCount = 5)
+
+        // A scan must not populate any sync field.
+        assertNull(DiagnosticsStore.lastSyncAt())
+        assertNull(DiagnosticsStore.lastSyncSuccess())
+        assertNull(DiagnosticsStore.lastSyncBeaconCount())
+    }
+
+    @Test
+    fun `recordError formats entry as epochMillis pipe message`() {
+        val before = System.currentTimeMillis()
+        DiagnosticsStore.recordError("boom")
+        val after = System.currentTimeMillis()
+
+        val errors = DiagnosticsStore.recentErrors()
+        assertEquals(1, errors.size)
+
+        val entry = errors.first()
+        val parts = entry.split(" | ", limit = 2)
+        assertEquals("entry should be '<epochMillis> | <message>'", 2, parts.size)
+
+        val ts = parts[0].toLong()
+        assertTrue("timestamp should be within the call window", ts in before..after)
+        assertEquals("boom", parts[1])
+    }
+
+    @Test
+    fun `recentErrors is a ring buffer capped at 10 dropping the oldest`() {
+        // Add 12 distinct errors; only the last 10 should survive, oldest-first.
+        repeat(12) { i -> DiagnosticsStore.recordError("err-$i") }
+
+        val errors = DiagnosticsStore.recentErrors()
+        assertEquals("ring buffer must cap at 10", 10, errors.size)
+
+        // The oldest two (err-0, err-1) must have been dropped.
+        assertTrue("err-0 should have been evicted", errors.none { it.endsWith(" | err-0") })
+        assertTrue("err-1 should have been evicted", errors.none { it.endsWith(" | err-1") })
+
+        // The surviving window is err-2 .. err-11, oldest first.
+        assertTrue("oldest survivor should be err-2", errors.first().endsWith(" | err-2"))
+        assertTrue("newest should be err-11", errors.last().endsWith(" | err-11"))
+
+        val messages = errors.map { it.substringAfter(" | ") }
+        assertEquals((2..11).map { "err-$it" }, messages)
+    }
+
+    @Test
+    fun `recentErrors returns a detached snapshot`() {
+        DiagnosticsStore.recordError("a")
+        val snapshot = DiagnosticsStore.recentErrors()
+        assertEquals(1, snapshot.size)
+
+        // A later error must not retroactively grow a previously taken snapshot.
+        DiagnosticsStore.recordError("b")
+
+        assertEquals("snapshot must be detached from later writes", 1, snapshot.size)
+        assertEquals(2, DiagnosticsStore.recentErrors().size)
+    }
+}

--- a/sdk/src/test/java/io/bearound/sdk/utilities/PushTokenStoreTest.kt
+++ b/sdk/src/test/java/io/bearound/sdk/utilities/PushTokenStoreTest.kt
@@ -1,0 +1,119 @@
+package io.bearound.sdk.utilities
+
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Tests the heartbeat delivery logic of [PushTokenStore].
+ *
+ * [PushTokenStore] is backed by [SecureStorage] (EncryptedSharedPreferences), which needs
+ * an Android [android.content.Context]; Robolectric supplies one. Each test re-initializes
+ * [SecureStorage] against a fresh Robolectric application and clears the persisted keys, so
+ * the tests are independent despite both objects being singletons.
+ */
+@RunWith(RobolectricTestRunner::class)
+class PushTokenStoreTest {
+
+    // Mirror of the keys PushTokenStore reads/writes (private consts there). Only used to
+    // simulate elapsed time by writing LAST_SENT_AT directly — the store reads it back.
+    private val tokenKey = "io.bearound.sdk.pushToken"
+    private val lastSentKey = "io.bearound.sdk.pushTokenLastSent"
+    private val lastSentAtKey = "io.bearound.sdk.pushTokenLastSentAt"
+
+    private val token = "fcm-token-abcdefghijklmnop-0001"
+
+    @Before
+    fun setUp() {
+        SecureStorage.initialize(ApplicationProvider.getApplicationContext())
+        // Ensure a clean slate even though Robolectric gives a fresh app per test.
+        SecureStorage.delete(tokenKey)
+        SecureStorage.delete(lastSentKey)
+        SecureStorage.delete(lastSentAtKey)
+    }
+
+    @Test
+    fun `never-sent token is returned by tokenForPayload`() {
+        PushTokenStore.setToken(token)
+
+        assertEquals(token, PushTokenStore.tokenForPayload())
+    }
+
+    @Test
+    fun `tokenForPayload returns null when there is no token at all`() {
+        assertNull(PushTokenStore.tokenForPayload())
+    }
+
+    @Test
+    fun `after markSent the same token is no longer offered`() {
+        PushTokenStore.setToken(token)
+        PushTokenStore.markSent()
+
+        assertNull("an already-sent, unchanged token should not be re-sent", PushTokenStore.tokenForPayload())
+    }
+
+    @Test
+    fun `a changed token is offered again`() {
+        PushTokenStore.setToken(token)
+        PushTokenStore.markSent()
+        assertNull(PushTokenStore.tokenForPayload())
+
+        val rotated = "fcm-token-ZZZZZZZZZZZZZZZZ-9999"
+        PushTokenStore.setToken(rotated)
+
+        assertEquals(rotated, PushTokenStore.tokenForPayload())
+    }
+
+    @Test
+    fun `heartbeat re-sends an unchanged token after more than 7 days`() {
+        PushTokenStore.setToken(token)
+        PushTokenStore.markSent()
+        assertNull("fresh send should suppress immediate re-send", PushTokenStore.tokenForPayload())
+
+        // Simulate the last successful send being 8 days ago by rewriting LAST_SENT_AT,
+        // which tokenForPayload reads back. The 7-day window (604800000 ms) is now exceeded.
+        val eightDaysAgo = System.currentTimeMillis() - 8L * 24 * 60 * 60 * 1000
+        SecureStorage.save(lastSentAtKey, eightDaysAgo.toString())
+
+        assertEquals(token, PushTokenStore.tokenForPayload())
+    }
+
+    @Test
+    fun `markSent records the sent token and a timestamp`() {
+        assertNull(PushTokenStore.lastSentAt())
+
+        val before = System.currentTimeMillis()
+        PushTokenStore.setToken(token)
+        PushTokenStore.markSent()
+        val after = System.currentTimeMillis()
+
+        val at = PushTokenStore.lastSentAt()
+        assertNotNull("lastSentAt should be set after markSent", at)
+        assertEquals(true, at!! in before..after)
+    }
+
+    @Test
+    fun `maskedToken shows first 8 and last 4 for a long token`() {
+        PushTokenStore.setToken(token)
+
+        // token = "fcm-token-abcdefghijklmnop-0001" -> "fcm-toke…0001"
+        assertEquals("fcm-toke…0001", PushTokenStore.maskedToken())
+    }
+
+    @Test
+    fun `maskedToken hides short tokens wholesale`() {
+        PushTokenStore.setToken("short12")
+
+        assertEquals("…", PushTokenStore.maskedToken())
+    }
+
+    @Test
+    fun `maskedToken is null when no token stored`() {
+        assertNull(PushTokenStore.maskedToken())
+    }
+}


### PR DESCRIPTION
## Android SDK — melhorias consolidadas (1 PR)

Consolida todo o trabalho de SDK do Android num PR só (substitui os antigos #48 e #50).

### Inclui
- **Auto-coleta de FCM** — `compileOnly firebase-messaging` + busca guardada (`tryAutoCollectFcmToken`); coleta automática se o app tem Firebase, sem forçar a dependência. `setPushToken(token)` mantido (fallback/forward).
- **Diagnostics** — `getInstance(context).diagnostics()` → snapshot (`BeAroundDiagnostics` + `summary()`).
- **TTL heartbeat** do push token — reenvia se mudou ou >7 dias.
- **Detecção mais rápida** em background — `SCAN_MODE_LOW_POWER` → `SCAN_MODE_BALANCED`.
- **Primeiros testes unitários** do módulo `sdk/` (20, via Robolectric).

### Teste
`./gradlew :sdk:compileReleaseKotlin` → BUILD SUCCESSFUL; `:sdk:testDebugUnitTest` → 20/20.

### ⚠️ Decisão
`firebase-messaging` como **compileOnly** (soft dependency) — apps sem Firebase não são afetados (guardado em runtime); apps com Firebase coletam automático.
