### PR TITLE
feat: auto-collect FCM token (compileOnly firebase, guarded)

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,6 +449,14 @@ val isForegroundScanningEnabled: Boolean = sdk.isForegroundScanningEnabled
 val pendingBatchCount: Int = sdk.pendingBatchCount
 ```
 
+### Push Notifications (FCM)
+
+If your app ships Firebase, `configure(...)` auto-collects the FCM token and sends it on the next sync. Firebase is a soft dependency (`compileOnly`): apps without it are unaffected. If you don't use Firebase, provide the token yourself:
+
+```kotlin
+sdk.setPushToken(token)
+```
+
 ### BeAroundSDKListener
 
 Implement this interface to receive SDK events:

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -136,4 +136,8 @@ dependencies {
     
     // Gson for JSON serialization (offline batch storage)
     implementation 'com.google.code.gson:gson:2.13.2'
+
+    // Firebase Cloud Messaging — soft dependency (compileOnly, not bundled). See tryAutoCollectFcmToken.
+    compileOnly 'com.google.firebase:firebase-messaging:24.0.0'
+    compileOnly 'com.google.firebase:firebase-common:21.0.0'
 }

--- a/sdk/src/main/java/io/bearound/sdk/BeAroundSDK.kt
+++ b/sdk/src/main/java/io/bearound/sdk/BeAroundSDK.kt
@@ -342,6 +342,7 @@ class BeAroundSDK private constructor() {
         listener?.onAppStateChanged(isInBackground = true)
     }
 
+    /** Configures and activates the SDK. Auto-collects the FCM token if Firebase is present (see [tryAutoCollectFcmToken]). */
     fun configure(
         businessToken: String,
         scanPrecision: ScanPrecision = ScanPrecision.MEDIUM,
@@ -376,8 +377,27 @@ class BeAroundSDK private constructor() {
 
         SDKConfigStorage.saveConfiguration(context, config)
 
+        tryAutoCollectFcmToken(context)
+
         if (isScanning) {
             startSyncTimer()
+        }
+    }
+
+    /** Best-effort FCM token fetch. Firebase is compileOnly, so guard against it being absent at runtime; falls back to [setPushToken]. */
+    private fun tryAutoCollectFcmToken(context: Context) {
+        try {
+            if (com.google.firebase.FirebaseApp.getApps(context).isEmpty()) return
+            com.google.firebase.messaging.FirebaseMessaging.getInstance().token
+                .addOnSuccessListener { token ->
+                    if (!token.isNullOrEmpty()) {
+                        PushTokenStore.setToken(token)
+                        Log.i(TAG, "FCM token auto-collected")
+                    }
+                }
+                .addOnFailureListener { e -> Log.w(TAG, "FCM token fetch failed: ${e.message}") }
+        } catch (t: Throwable) {
+            Log.i(TAG, "Firebase not available; client must call setPushToken() to provide the FCM token")
         }
     }
 


### PR DESCRIPTION
## What
Auto-collect the **FCM push token** on Android when the host app has Firebase — without forcing Firebase on apps that don't use it.

Today the SDK only stores a token if the client calls `setPushToken(token)` and sends it in the device payload; it never fetches the FCM token itself. iOS auto-captures the APNs token (swizzle) — this brings Android toward parity.

## How
- **`compileOnly`** soft dependency on `firebase-messaging` + `firebase-common` — the SDK compiles against FCM but does **NOT** bundle or force Firebase.
- `tryAutoCollectFcmToken(context)` in `configure()`: guarded — only fetches if `FirebaseApp.getApps(context)` is non-empty (host has Firebase). `catch (Throwable)` swallows `NoClassDefFoundError` for apps without firebase-messaging → graceful fallback to `setPushToken`.
- `setPushToken(token)` preserved (manual/forward path; also how RN/Flutter feed the token).

## ⚠️ Dependency decision to confirm
`firebase-messaging` is wired as **compileOnly** (soft dependency), not `implementation`:
- Apps **without** Firebase: unaffected — not bundled, not forced, runtime guarded (no crash).
- Apps **with** Firebase: auto-collect "just works", zero wiring.
- Host's own Firebase version wins at runtime (compiled against `firebase-messaging:24.0.0` / `firebase-common:21.0.0`; APIs used are long-stable).

## Test
`./gradlew :sdk:compileReleaseKotlin` → **BUILD SUCCESSFUL**.
