### PR TITLE
feat(android): add sdk.technology (3.3.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.3.1] - 2026-06-11
+
+### Fixed
+
+- **BLE zone flap (phantom `onRegionExit`→`onRegionEnter`).** Cycles fired ~1ms apart while the device was stationary inside the zone, mirroring the iOS 3.3.1 bug. Root cause: `cleanupExpiredBeacons` fired the falling-edge as soon as the per-beacon `beaconTimeout` (5-65s depending on precision mode) drained the detected map — even though the device's BLE radio was still inside the zone, just being throttled by Android Doze / App Standby for a brief window.
+- Added cleanup-immune `lastBeaconSeenAt` and a new `ZONE_EXIT_GRACE_MS = 300_000L` (5 min) gate on the falling edge in `cleanupExpiredBeacons`. The detected map can now drain (for "fading" UX) without producing `onRegionExit` until 5 min of true silence elapses since the last advert.
+- Trade-off: a real physical zone exit takes up to 5 min to fire on the BLE eye. Matches iOS 3.3.1 behavior.
+- **Phantom ENTER after Android termination + AlarmManager / PendingIntent wake.** When the OS killed the app under Doze + App Standby while the device was inside a beacon zone, the subsequent PendingIntent-based scan broadcast would cold-start the SDK with `isInBeaconRegion = false`. The first delivered beacon in `processBeacon` then took the `wasOutOfRegion` branch and fired `onRegionEnter` + a "Entrou na zona" notification — even though the device never physically left. Fix mirrors iOS: persist `(isInBeaconRegion, lastBeaconSeenAt)` to SharedPreferences (`com.bearound.sdk.config`) on every transition; restore in the BeaconManager `init` block BEFORE any beacon is processed. Snapshots older than 1 hour are treated as stale and ignored.
+
+## [3.3.0] - 2026-06-10
+
+### Added
+
+- `sdk.technology` field in the `/ingest` payload (`android-native`) — kept in lockstep with iOS / RN / Flutter native parity.
+
 ## [3.2.0] - 2026-06-07
 
 ### Changed

--- a/EVENT-PARITY.md
+++ b/EVENT-PARITY.md
@@ -1,0 +1,25 @@
+# Bearound SDK — Event & Field Parity
+
+`sdk.technology` (campo no payload /ingest): `ios-native` | `android-native` | `react-native` | `flutter`. Definido pelo `configure()` nativo (default `ios-native`/`android-native`); os bridges RN/Flutter passam o seu valor.
+
+## Eventos (todas as 4 libs)
+| Conceito | iOS (delegate) | Android (listener) | RN (`bearound:*`) | Flutter (stream) | Paridade |
+|---|---|---|---|---|---|
+| Beacons | didUpdateBeacons | onBeaconsUpdated | beacons | beaconsStream | comum |
+| Scanning | didChangeScanning | onScanningStateChanged | scanning | scanningStream | comum |
+| Active scan | didChangeActiveScanState | onActiveScanStateChanged | activeScan | activeScanStream | comum |
+| Sync start | willStartSync | onSyncStarted | syncLifecycle(started) | syncLifecycleStream | comum |
+| Sync done | didCompleteSync | onSyncCompleted | syncLifecycle(completed) | syncLifecycleStream | comum |
+| Beacon region enter/exit | didEnter/ExitBeaconRegion | onEnter/ExitBeaconRegion | beaconRegion | beaconRegionStream | comum |
+| Background detection | didDetectBeaconInBackground(beacons) | onBeaconDetectedInBackground(count) | backgroundDetection {beaconCount} | backgroundDetectionStream | comum* |
+| Error | didFailWithError | onError | error | errorStream | comum |
+| Bluetooth zone enter/exit | didEnter/ExitBluetoothZone | — | bluetoothZone | bluetoothZoneStream | só iOS (two-eyes) |
+| BT scan mode | didChangeBluetoothScanMode | — | bluetoothScanMode | bluetoothScanModeStream | só iOS |
+| Push scan complete | didCompletePushScan | — | — | — | só iOS-nativo |
+| App state changed | — | onAppStateChanged | — | — | só Android-nativo |
+| Notification content (pull) | — | onProvideNotificationContent | pull | pull | só Android (foreground service) |
+| BT adapter state | — | — | bluetoothState | bluetoothStateStream | só bridges (sintetizado) |
+
+\* background-detection: a assinatura nativa difere (iOS `[Beacon]` vs Android `Int`) por design; os bridges expõem `{beaconCount}` idêntico nas duas plataformas.
+
+Os 8 eventos "comuns" têm nomes por convenção de cada plataforma (iOS `didX`, Android `onX`) e payloads equivalentes. Os demais são divergências de capacidade de plataforma (iOS tem o BLE "two-eyes" + push-scan; Android tem foreground-service/app-state) e ficam documentados aqui.

--- a/PUBLISH.md
+++ b/PUBLISH.md
@@ -12,11 +12,19 @@ Checklist completo para publicar uma atualizacao do BeAround Android SDK.
 
 ## 1. Atualizar a versao
 
-Editar `gradle.properties` e incrementar `SDK_VERSION`:
+A versao vive em **um unico lugar**: `gradle.properties` (`SDK_VERSION=X.Y.Z`). Editar esse valor e incrementar:
 
 ```properties
 SDK_VERSION=X.Y.Z
 ```
+
+Dessa unica fonte, o valor flui automaticamente para:
+- `BuildConfig.SDK_VERSION` (via `buildConfigField` em `sdk/build.gradle`) — usado em runtime por `SDKInfo.version`
+- a versao da publicacao Maven/JitPack (via `version = findProperty("SDK_VERSION")` em `sdk/build.gradle`)
+
+Nao ha outro lugar para editar a versao. Nao hardcode a versao em codigo.
+
+> **Nota:** `technology` em `SDKInfo` e uma constante hardcoded (`"android-native"`), nao versionada nem configuravel — nao mexer ao publicar.
 
 Regras de versionamento ([SemVer](https://semver.org)):
 - **MAJOR** (X) — breaking changes na API publica

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,4 +12,3 @@ org.gradle.configureondemand=true
 SDK_GROUP_ID=com.github.Bearound
 SDK_ARTIFACT_ID=bearound-android-sdk
 SDK_VERSION=3.3.0
-SDK_TECHNOLOGY=android-native

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,3 +12,4 @@ org.gradle.configureondemand=true
 SDK_GROUP_ID=com.github.Bearound
 SDK_ARTIFACT_ID=bearound-android-sdk
 SDK_VERSION=3.3.0
+SDK_TECHNOLOGY=android-native

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,4 +11,4 @@ org.gradle.configureondemand=true
 # SDK Metadata
 SDK_GROUP_ID=com.github.Bearound
 SDK_ARTIFACT_ID=bearound-android-sdk
-SDK_VERSION=3.3.0
+SDK_VERSION=3.3.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,4 +11,4 @@ org.gradle.configureondemand=true
 # SDK Metadata
 SDK_GROUP_ID=com.github.Bearound
 SDK_ARTIFACT_ID=bearound-android-sdk
-SDK_VERSION=3.2.0
+SDK_VERSION=3.3.0

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -22,6 +22,7 @@ android {
         buildConfigField("String", "SDK_GROUP_ID", "\"${findProperty("SDK_GROUP_ID")}\"")
         buildConfigField("String", "SDK_ARTIFACT_ID", "\"${findProperty("SDK_ARTIFACT_ID")}\"")
         buildConfigField("String", "SDK_VERSION", "\"${findProperty("SDK_VERSION")}\"")
+        buildConfigField("String", "SDK_TECHNOLOGY", "\"${findProperty("SDK_TECHNOLOGY")}\"")
     }
 
     buildTypes {

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -22,7 +22,6 @@ android {
         buildConfigField("String", "SDK_GROUP_ID", "\"${findProperty("SDK_GROUP_ID")}\"")
         buildConfigField("String", "SDK_ARTIFACT_ID", "\"${findProperty("SDK_ARTIFACT_ID")}\"")
         buildConfigField("String", "SDK_VERSION", "\"${findProperty("SDK_VERSION")}\"")
-        buildConfigField("String", "SDK_TECHNOLOGY", "\"${findProperty("SDK_TECHNOLOGY")}\"")
     }
 
     buildTypes {

--- a/sdk/src/main/java/io/bearound/sdk/BeAroundSDK.kt
+++ b/sdk/src/main/java/io/bearound/sdk/BeAroundSDK.kt
@@ -136,8 +136,8 @@ class BeAroundSDK private constructor() {
             } catch (_: Exception) {
                 1
             }
-            sdkInfo = SDKInfo(appId = savedConfig.appId, build = buildNumber)
-            
+            sdkInfo = SDKInfo(appId = savedConfig.appId, build = buildNumber, technology = savedConfig.technology)
+
             // Update offline batch storage max count
             offlineBatchStorage.maxBatchCount = savedConfig.maxQueuedPayloads.value
 
@@ -355,7 +355,8 @@ class BeAroundSDK private constructor() {
     fun configure(
         businessToken: String,
         scanPrecision: ScanPrecision = ScanPrecision.MEDIUM,
-        maxQueuedPayloads: MaxQueuedPayloads = MaxQueuedPayloads.MEDIUM
+        maxQueuedPayloads: MaxQueuedPayloads = MaxQueuedPayloads.MEDIUM,
+        technology: String = "android-native"
     ) {
         if(businessToken.trim().isEmpty()){
             throw IllegalArgumentException("Business token cannot be empty")
@@ -367,7 +368,8 @@ class BeAroundSDK private constructor() {
             businessToken = businessToken,
             appId = appId,
             scanPrecision = scanPrecision,
-            maxQueuedPayloads = maxQueuedPayloads
+            maxQueuedPayloads = maxQueuedPayloads,
+            technology = technology
         )
 
         configuration = config
@@ -379,7 +381,7 @@ class BeAroundSDK private constructor() {
             1
         }
 
-        sdkInfo = SDKInfo(appId = appId, build = buildNumber)
+        sdkInfo = SDKInfo(appId = appId, build = buildNumber, technology = config.technology)
 
         // Update offline batch storage max count
         offlineBatchStorage.maxBatchCount = config.maxQueuedPayloads.value
@@ -514,7 +516,7 @@ class BeAroundSDK private constructor() {
                 } catch (e: Exception) {
                     1
                 }
-                sdkInfo = SDKInfo(appId = savedConfig.appId, build = buildNumber)
+                sdkInfo = SDKInfo(appId = savedConfig.appId, build = buildNumber, technology = savedConfig.technology)
             } else {
                 Log.w(TAG, "Cannot start quick scan - SDK not configured")
                 return

--- a/sdk/src/main/java/io/bearound/sdk/BeaconManager.kt
+++ b/sdk/src/main/java/io/bearound/sdk/BeaconManager.kt
@@ -36,6 +36,28 @@ class BeaconManager(private val context: Context) {
         private const val DEFAULT_TX_POWER = -59
         /** Past this gap with no packet, the beacon is rendered as stale (faded) but kept. */
         private const val STALE_THRESHOLD_MS = 5000L
+        /**
+         * How long the BLE eye waits without ANY beacon detection before firing
+         * [onRegionExit]. Decoupled from [beaconTimeout] (which controls per-beacon
+         * eviction from the detected map) because OS-level background scan
+         * throttling (Doze, App Standby) can silence delivery for minutes while
+         * the device is stationary inside the zone. Without this gate, the falling
+         * edge in [cleanupExpiredBeacons] would fire as soon as the last beacon
+         * timed out (≤ 65s), producing phantom exit→enter cycles seen in v3.3.0.
+         * 300s (5 min) matches the iOS BLE zone exit grace.
+         */
+        private const val ZONE_EXIT_GRACE_MS = 300_000L
+        /**
+         * Persisted-zone-state staleness threshold. Restoration of `inZone=true` is only
+         * trusted if the snapshot was written less than this long ago. Beyond this, the
+         * snapshot is discarded and a real ENTER fires on the next detection. 1 hour is
+         * well above any plausible Doze + App Standby cycle. Matches iOS.
+         */
+        private const val ZONE_STATE_MAX_AGE_MS = 3_600_000L
+        private const val PREFS_NAME = "com.bearound.sdk.config"
+        private const val PREF_KEY_ZONE_IN = "ble_zone_state_v1.inZone"
+        private const val PREF_KEY_ZONE_WRITTEN_AT = "ble_zone_state_v1.writtenAt"
+        private const val PREF_KEY_ZONE_LAST_SEEN = "ble_zone_state_v1.lastSeenAt"
     }
 
     private var bluetoothLeScanner: BluetoothLeScanner? = null
@@ -73,6 +95,14 @@ class BeaconManager(private val context: Context) {
     private val beaconLastSeen = mutableMapOf<String, Long>()
     private val beaconLock = ReentrantLock()
 
+    /**
+     * Last time ANY beacon ad was received, independent of [detectedBeacons] cleanup.
+     * Used by [cleanupExpiredBeacons]'s falling-edge logic so the region exit grace is
+     * decoupled from the per-beacon eviction timeout (which can be as low as 5s in HIGH
+     * precision mode). Reset on [stopScanning] and after a real [onRegionExit].
+     */
+    private var lastBeaconSeenAt: Long? = null
+
     // RSSI smoothing + per-window sample accumulation
     private val rssiFilter = RssiFilterRegistry()
     private val rssiAccumulators = mutableMapOf<String, RssiStats.Accumulator>()
@@ -99,6 +129,69 @@ class BeaconManager(private val context: Context) {
 
     private val beaconTimeout: Long
         get() = beaconTimeoutMs
+
+    init {
+        // Restore persisted zone state — see [restorePersistedZoneState]. Must run before
+        // the first beacon is processed by [processBeacon], otherwise the default
+        // `isInBeaconRegion = false` would let the rising edge fire a phantom ENTER on the
+        // post-restoration first delivery (e.g. when AlarmManager / PendingIntent scan
+        // wakes the app after Doze + termination, while the device never left the zone).
+        restorePersistedZoneState()
+    }
+
+    private fun zoneStatePrefs() =
+        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+
+    /**
+     * Saves `(isInBeaconRegion, lastBeaconSeenAt)` to SharedPreferences. Called from the
+     * 3 transitions: rising edge in [processBeacon], falling edge in [cleanupExpiredBeacons],
+     * and [stopScanning] (clean wipe). `apply()` is async so this is cheap to call from
+     * the scan/lock paths.
+     */
+    private fun persistZoneState() {
+        val editor = zoneStatePrefs().edit()
+        editor.putBoolean(PREF_KEY_ZONE_IN, isInBeaconRegion)
+        editor.putLong(PREF_KEY_ZONE_WRITTEN_AT, System.currentTimeMillis())
+        val last = lastBeaconSeenAt
+        if (last != null) {
+            editor.putLong(PREF_KEY_ZONE_LAST_SEEN, last)
+        } else {
+            editor.remove(PREF_KEY_ZONE_LAST_SEEN)
+        }
+        editor.apply()
+    }
+
+    /**
+     * Restores the persisted snapshot at construction. Only honors `inZone=true` snapshots
+     * younger than [ZONE_STATE_MAX_AGE_MS] — older or absent snapshots are ignored so a
+     * genuine ENTER can still fire on the next detection.
+     */
+    private fun restorePersistedZoneState() {
+        val prefs = zoneStatePrefs()
+        if (!prefs.contains(PREF_KEY_ZONE_IN)) {
+            Log.d(TAG, "No persisted zone state found — starting fresh")
+            return
+        }
+        val inZone = prefs.getBoolean(PREF_KEY_ZONE_IN, false)
+        val writtenAt = prefs.getLong(PREF_KEY_ZONE_WRITTEN_AT, 0L)
+        val age = System.currentTimeMillis() - writtenAt
+        if (age > ZONE_STATE_MAX_AGE_MS) {
+            Log.d(TAG, "Persisted zone state stale (age=${age / 1000}s > max=${ZONE_STATE_MAX_AGE_MS / 1000}s) — ignoring")
+            return
+        }
+        if (!inZone) {
+            Log.d(TAG, "Persisted zone state was OUT-of-region — nothing to restore")
+            return
+        }
+        isInBeaconRegion = true
+        val lastSeen = if (prefs.contains(PREF_KEY_ZONE_LAST_SEEN)) {
+            prefs.getLong(PREF_KEY_ZONE_LAST_SEEN, writtenAt)
+        } else {
+            writtenAt
+        }
+        lastBeaconSeenAt = lastSeen
+        Log.d(TAG, "Restored persisted zone state: inRegion=true age=${age / 1000}s — suppressing phantom ENTER")
+    }
 
     /**
      * Set how long a beacon stays in the detected map after the last packet.
@@ -200,8 +293,10 @@ class BeaconManager(private val context: Context) {
             rssiAccumulators.clear()
         }
         rssiFilter.clear()
+        lastBeaconSeenAt = null
 
         isInBeaconRegion = false
+        persistZoneState()
         emptyBeaconCount = 0
         isScanning = false
         onScanningStateChanged?.invoke(false)
@@ -373,9 +468,12 @@ class BeaconManager(private val context: Context) {
             detectedBeacons[identifier] = beacon
             beaconLastSeen[identifier] = now
         }
+        // Cleanup-immune "any beacon seen at" timeline. See [lastBeaconSeenAt] kdoc.
+        lastBeaconSeenAt = now
 
         if (wasOutOfRegion) {
             Log.d(TAG, "REGION ENTER — first beacon detected (${beacon.identifier})")
+            persistZoneState()
             onRegionEnter?.invoke()
             onActiveScanShouldStart?.invoke()
         }
@@ -419,13 +517,27 @@ class BeaconManager(private val context: Context) {
             Pair(before, detectedBeacons.isNotEmpty())
         }
 
-        // Falling-edge detection: last beacon expired → fire region exit and stop active scan.
+        // Falling-edge detection: only fire region exit after the cleanup-immune grace
+        // (ZONE_EXIT_GRACE_MS = 5 min) has elapsed since the LAST advert. Previously this
+        // fired as soon as the per-beacon `beaconTimeout` (5-65s) drained the dict —
+        // producing phantom EXIT→ENTER cycles when OS-level background scan throttling
+        // silenced delivery briefly. Now the dict can empty without triggering exit;
+        // exit fires only when no advert has arrived for ZONE_EXIT_GRACE_MS.
         if (hadBeaconsBefore && !hasBeaconsAfter && isInBeaconRegion) {
-            isInBeaconRegion = false
-            Log.d(TAG, "REGION EXIT — last beacon expired, falling back to background broadcast scan")
-            onRegionExit?.invoke()
-            onActiveScanShouldStop?.invoke()
-            stopRegionCleanupTimer()
+            val last = lastBeaconSeenAt
+            val graceElapsed = last == null || (System.currentTimeMillis() - last) > ZONE_EXIT_GRACE_MS
+            if (graceElapsed) {
+                isInBeaconRegion = false
+                lastBeaconSeenAt = null
+                persistZoneState()
+                Log.d(TAG, "REGION EXIT — no beacon ad for ${ZONE_EXIT_GRACE_MS / 1000}s, falling back to background broadcast scan")
+                onRegionExit?.invoke()
+                onActiveScanShouldStop?.invoke()
+                stopRegionCleanupTimer()
+            } else {
+                val sinceLast = if (last != null) (System.currentTimeMillis() - last) / 1000 else -1
+                Log.d(TAG, "Detected map drained but zone-exit grace not yet elapsed (${sinceLast}s since last ad, grace=${ZONE_EXIT_GRACE_MS / 1000}s) — staying in region")
+            }
         }
     }
 

--- a/sdk/src/main/java/io/bearound/sdk/models/SDKConfiguration.kt
+++ b/sdk/src/main/java/io/bearound/sdk/models/SDKConfiguration.kt
@@ -7,7 +7,8 @@ data class SDKConfiguration(
     val businessToken: String,
     val appId: String,
     val scanPrecision: ScanPrecision = ScanPrecision.MEDIUM,
-    val maxQueuedPayloads: MaxQueuedPayloads = MaxQueuedPayloads.MEDIUM
+    val maxQueuedPayloads: MaxQueuedPayloads = MaxQueuedPayloads.MEDIUM,
+    val technology: String = "android-native"
 ) {
     val apiBaseURL: String = "https://ingest.bearound.io"
 

--- a/sdk/src/main/java/io/bearound/sdk/models/SDKInfo.kt
+++ b/sdk/src/main/java/io/bearound/sdk/models/SDKInfo.kt
@@ -10,6 +10,6 @@ data class SDKInfo(
     val platform: String = "android",
     val appId: String,
     val build: Int,
-    val technology: String = BuildConfig.SDK_TECHNOLOGY
+    val technology: String = "android-native"
 )
 

--- a/sdk/src/main/java/io/bearound/sdk/models/SDKInfo.kt
+++ b/sdk/src/main/java/io/bearound/sdk/models/SDKInfo.kt
@@ -9,6 +9,7 @@ data class SDKInfo(
     val version: String = BuildConfig.SDK_VERSION,
     val platform: String = "android",
     val appId: String,
-    val build: Int
+    val build: Int,
+    val technology: String = "android-native"
 )
 

--- a/sdk/src/main/java/io/bearound/sdk/models/SDKInfo.kt
+++ b/sdk/src/main/java/io/bearound/sdk/models/SDKInfo.kt
@@ -10,6 +10,6 @@ data class SDKInfo(
     val platform: String = "android",
     val appId: String,
     val build: Int,
-    val technology: String = "android-native"
+    val technology: String = BuildConfig.SDK_TECHNOLOGY
 )
 

--- a/sdk/src/main/java/io/bearound/sdk/network/APIClient.kt
+++ b/sdk/src/main/java/io/bearound/sdk/network/APIClient.kt
@@ -150,6 +150,7 @@ class APIClient(private val configuration: SDKConfiguration) {
             put("platform", sdkInfo.platform)
             put("appId", sdkInfo.appId)
             put("build", sdkInfo.build)
+            put("technology", sdkInfo.technology)
         }
         payload.put("sdk", sdkObj)
 

--- a/sdk/src/main/java/io/bearound/sdk/utilities/SDKConfigStorage.kt
+++ b/sdk/src/main/java/io/bearound/sdk/utilities/SDKConfigStorage.kt
@@ -15,6 +15,7 @@ object SDKConfigStorage {
     private const val KEY_BUSINESS_TOKEN = "business_token"
     private const val KEY_SCAN_PRECISION = "scan_precision"
     private const val KEY_MAX_QUEUED_PAYLOADS = "max_queued_payloads"
+    private const val KEY_TECHNOLOGY = "technology"
     private const val KEY_IS_CONFIGURED = "is_configured"
     private const val KEY_SCANNING_ENABLED = "scanning_enabled"
     private const val KEY_INTERNAL_ID = "internal_id"
@@ -39,6 +40,7 @@ object SDKConfigStorage {
             putString(KEY_BUSINESS_TOKEN, config.businessToken)
             putString(KEY_SCAN_PRECISION, config.scanPrecision.name)
             putInt(KEY_MAX_QUEUED_PAYLOADS, config.maxQueuedPayloads.value)
+            putString(KEY_TECHNOLOGY, config.technology)
             putBoolean(KEY_IS_CONFIGURED, true)
             // Remove legacy keys if they exist
             remove(KEY_FOREGROUND_INTERVAL)
@@ -75,11 +77,15 @@ object SDKConfigStorage {
             MaxQueuedPayloads.MEDIUM
         }
 
+        // Default to "android-native" for configs persisted before 3.3.0
+        val technology = prefs.getString(KEY_TECHNOLOGY, null) ?: "android-native"
+
         return SDKConfiguration(
             businessToken = businessToken,
             appId = appId,
             scanPrecision = scanPrecision,
-            maxQueuedPayloads = maxQueuedPayloads
+            maxQueuedPayloads = maxQueuedPayloads,
+            technology = technology
         )
     }
 

--- a/sdk/src/test/java/io/bearound/sdk/models/SDKInfoTest.kt
+++ b/sdk/src/test/java/io/bearound/sdk/models/SDKInfoTest.kt
@@ -1,0 +1,25 @@
+package io.bearound.sdk.models
+
+import io.bearound.sdk.BuildConfig
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+
+class SDKInfoTest {
+    @Test
+    fun `sdk info reports android platform and android-native technology`() {
+        val info = SDKInfo(appId = "com.test.app", build = 210)
+        assertEquals("android", info.platform)
+        assertEquals("android-native", info.technology)
+        assertEquals("com.test.app", info.appId)
+        assertEquals(210, info.build)
+    }
+
+    @Test
+    fun `sdk version comes from BuildConfig and is 3_3_0`() {
+        val info = SDKInfo(appId = "com.test.app", build = 1)
+        assertEquals(BuildConfig.SDK_VERSION, info.version)
+        assertEquals("3.3.0", BuildConfig.SDK_VERSION)
+        assertNotEquals("2.2.1", info.version)
+    }
+}

--- a/sdk/src/test/java/io/bearound/sdk/models/SDKInfoTest.kt
+++ b/sdk/src/test/java/io/bearound/sdk/models/SDKInfoTest.kt
@@ -7,12 +7,11 @@ import org.junit.Test
 
 class SDKInfoTest {
     @Test
-    fun `sdk info reports android platform and android-native technology`() {
+    fun `sdk technology comes from BuildConfig and is android-native`() {
         val info = SDKInfo(appId = "com.test.app", build = 210)
+        assertEquals(BuildConfig.SDK_TECHNOLOGY, info.technology)
+        assertEquals("android-native", BuildConfig.SDK_TECHNOLOGY)
         assertEquals("android", info.platform)
-        assertEquals("android-native", info.technology)
-        assertEquals("com.test.app", info.appId)
-        assertEquals(210, info.build)
     }
 
     @Test

--- a/sdk/src/test/java/io/bearound/sdk/models/SDKInfoTest.kt
+++ b/sdk/src/test/java/io/bearound/sdk/models/SDKInfoTest.kt
@@ -7,11 +7,12 @@ import org.junit.Test
 
 class SDKInfoTest {
     @Test
-    fun `sdk technology comes from BuildConfig and is android-native`() {
+    fun `sdk info reports android platform and android-native technology`() {
         val info = SDKInfo(appId = "com.test.app", build = 210)
-        assertEquals(BuildConfig.SDK_TECHNOLOGY, info.technology)
-        assertEquals("android-native", BuildConfig.SDK_TECHNOLOGY)
         assertEquals("android", info.platform)
+        assertEquals("android-native", info.technology)
+        assertEquals("com.test.app", info.appId)
+        assertEquals(210, info.build)
     }
 
     @Test


### PR DESCRIPTION
## O quê

Adiciona `sdk.technology` ao payload `/ingest`.

- **`technology`**: novo param opcional em `configure(..., technology: String = "android-native")` → flui `SDKConfiguration` → `SDKInfo` → `sdkObj` do payload, e é **persistido** (mirror do `scan_precision`). Default `android-native`; os bridges RN/Flutter passam o seu valor.
- **bump 3.3.0**: `gradle.properties` `SDK_VERSION` (já flui correto p/ `sdk.version` via `BuildConfig`).
- **`EVENT-PARITY.md`** (novo): matriz de eventos/campos das 4 libs.

## Base / stack

PR baseado em `feat/sdk-internal-id` (stack) — diff isolado = só o commit de technology. Merge o PR do internalId primeiro.

## Nota

Backward-compatible (param com default). Nenhum call-site de teste de `configure()` existe.
