### PR TITLE
fix(android): endurece start do FGS + exige BLUETOOTH_SCAN no 12+ (v3.4.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.4.5] - 2026-07-01
+
+### Fixed
+
+- **Second FGS crash mode (`ForegroundServiceStartNotAllowedException`).** The 3.4.4 fix only caught the `SecurityException` thrown inside `onStartCommand` when Bluetooth permission was missing. A distinct crash — `ForegroundServiceStartNotAllowedException` (a subclass of `IllegalStateException`) — is thrown earlier, at `context.startForegroundService()`, when the service is started from the background without a valid background-start exemption (Android 12+). `BeaconScanService.start()` and `updateNotification()` now wrap that call in try/catch and skip instead of crashing (background detection still runs via the PendingIntent scan).
+- **Log spam from location-only permission on Android 12+.** `BeaconManager`/`BluetoothManager.checkPermissions()` returned `location || bluetoothScan`, so with location-only granted the SDK attempted a BLE scan the OS rejected with a caught `SecurityException` (several per duty cycle, no detection). On Android 12+ the SDK now requires `BLUETOOTH_SCAN` directly — location never unlocks the scan on 12+ (the manifest uses `neverForLocation`); Android <12 keeps the legacy location gate. `BackgroundScanManager.enableBackgroundScanning()` gets the same guard for the ungated `restartScanningFromBackground` path.
+
 ## [3.4.4] - 2026-07-01
 
 ### Fixed

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,4 +11,4 @@ org.gradle.configureondemand=true
 # SDK Metadata
 SDK_GROUP_ID=com.github.Bearound
 SDK_ARTIFACT_ID=bearound-android-sdk
-SDK_VERSION=3.4.4
+SDK_VERSION=3.4.5

--- a/sdk/src/main/java/io/bearound/sdk/BeaconManager.kt
+++ b/sdk/src/main/java/io/bearound/sdk/BeaconManager.kt
@@ -666,11 +666,20 @@ class BeaconManager(private val context: Context) {
     }
 
     private fun checkPermissions(): Boolean {
-        // Two "eyes": Location and Bluetooth. Scan should proceed if AT LEAST ONE is granted.
-        // - Android 12+: BLUETOOTH_SCAN alone is sufficient (manifest uses neverForLocation).
-        // - Android <12: ACCESS_FINE/COARSE_LOCATION alone is sufficient (legacy BLE scan model;
-        //   BLUETOOTH/BLUETOOTH_ADMIN are normal permissions, auto-granted at install).
-        val locationPermission =
+        // The BLE-scan gate is version-dependent:
+        // - Android 12+ (S+): ONLY BLUETOOTH_SCAN unlocks the scan (manifest uses
+        //   neverForLocation). Location does NOT unlock it — the OS BluetoothLeScanner
+        //   requires BLUETOOTH_SCAN, so passing with location-only made the SDK attempt a
+        //   scan the OS then blocked with a (caught) SecurityException — polluting the log
+        //   with no detection. So on 12+ we require BLUETOOTH_SCAN directly.
+        // - Android <12: legacy model — ACCESS_FINE/COARSE_LOCATION unlocks the BLE scan
+        //   (BLUETOOTH/BLUETOOTH_ADMIN are install-time normal permissions).
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            ContextCompat.checkSelfPermission(
+                context,
+                Manifest.permission.BLUETOOTH_SCAN
+            ) == PackageManager.PERMISSION_GRANTED
+        } else {
             ContextCompat.checkSelfPermission(
                 context,
                 Manifest.permission.ACCESS_FINE_LOCATION
@@ -679,18 +688,6 @@ class BeaconManager(private val context: Context) {
                 context,
                 Manifest.permission.ACCESS_COARSE_LOCATION
             ) == PackageManager.PERMISSION_GRANTED
-
-        val bluetoothScanPermission = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            ContextCompat.checkSelfPermission(
-                context,
-                Manifest.permission.BLUETOOTH_SCAN
-            ) == PackageManager.PERMISSION_GRANTED
-        } else {
-            // Pre-Android-12, BLUETOOTH/BLUETOOTH_ADMIN are install-time normal permissions.
-            // Treat as available so that location-only grants still unlock the scan.
-            true
         }
-
-        return locationPermission || bluetoothScanPermission
     }
 }

--- a/sdk/src/main/java/io/bearound/sdk/BluetoothManager.kt
+++ b/sdk/src/main/java/io/bearound/sdk/BluetoothManager.kt
@@ -182,10 +182,17 @@ class BluetoothManager(private val context: Context) {
     }
 
     private fun checkPermissions(): Boolean {
-        // Two "eyes": Location and Bluetooth. Scan proceeds if AT LEAST ONE is granted.
-        // - Android 12+ (neverForLocation flag): BLUETOOTH_SCAN alone is sufficient.
-        // - Android <12: ACCESS_FINE/COARSE_LOCATION alone is sufficient (legacy BLE).
-        val hasLocation =
+        // Version-dependent BLE-scan gate (mirrors BeaconManager):
+        // - Android 12+ (S+): ONLY BLUETOOTH_SCAN unlocks the scan (manifest neverForLocation).
+        //   Location does NOT unlock it — passing with location-only made the SDK attempt a
+        //   scan the OS blocked with a caught SecurityException. So require BLUETOOTH_SCAN.
+        // - Android <12: legacy model — ACCESS_FINE/COARSE_LOCATION unlocks the BLE scan.
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            ContextCompat.checkSelfPermission(
+                context,
+                Manifest.permission.BLUETOOTH_SCAN
+            ) == PackageManager.PERMISSION_GRANTED
+        } else {
             ContextCompat.checkSelfPermission(
                 context,
                 Manifest.permission.ACCESS_FINE_LOCATION
@@ -194,16 +201,6 @@ class BluetoothManager(private val context: Context) {
                 context,
                 Manifest.permission.ACCESS_COARSE_LOCATION
             ) == PackageManager.PERMISSION_GRANTED
-
-        val hasBluetoothScan = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            ContextCompat.checkSelfPermission(
-                context,
-                Manifest.permission.BLUETOOTH_SCAN
-            ) == PackageManager.PERMISSION_GRANTED
-        } else {
-            true
         }
-
-        return hasLocation || hasBluetoothScan
     }
 }

--- a/sdk/src/main/java/io/bearound/sdk/background/BackgroundScanManager.kt
+++ b/sdk/src/main/java/io/bearound/sdk/background/BackgroundScanManager.kt
@@ -1,5 +1,6 @@
 package io.bearound.sdk.background
 
+import android.Manifest
 import android.annotation.SuppressLint
 import android.app.PendingIntent
 import android.bluetooth.le.BluetoothLeScanner
@@ -7,6 +8,7 @@ import android.bluetooth.le.ScanFilter
 import android.bluetooth.le.ScanSettings
 import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.os.Build
 import android.util.Log
 import androidx.annotation.RequiresApi
@@ -32,6 +34,16 @@ class BackgroundScanManager(private val context: Context) {
      */
     @SuppressLint("MissingPermission")
     fun enableBackgroundScanning() {
+        // On Android 12+ the PendingIntent scan requires BLUETOOTH_SCAN. Without it the OS
+        // throws SecurityException (caught, but it floods the log on every retry). This path
+        // is reached ungated via restartScanningFromBackground, so check here too — skip
+        // silently, consistent with the managers' permission gate.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S &&
+            context.checkSelfPermission(Manifest.permission.BLUETOOTH_SCAN) != PackageManager.PERMISSION_GRANTED
+        ) {
+            Log.d(TAG, "Skipping background scan — BLUETOOTH_SCAN not granted (Android 12+)")
+            return
+        }
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             enableBluetoothScanBroadcast()
         } else {

--- a/sdk/src/main/java/io/bearound/sdk/background/BeaconScanService.kt
+++ b/sdk/src/main/java/io/bearound/sdk/background/BeaconScanService.kt
@@ -48,10 +48,22 @@ class BeaconScanService : Service() {
                 putExtra(EXTRA_CHANNEL_ID, config.notificationChannelId)
                 putExtra(EXTRA_CHANNEL_NAME, config.notificationChannelName)
             }
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                context.startForegroundService(intent)
-            } else {
-                context.startService(intent)
+            try {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                    context.startForegroundService(intent)
+                } else {
+                    context.startService(intent)
+                }
+            } catch (e: IllegalStateException) {
+                // Android 12+ lança ForegroundServiceStartNotAllowedException (subclasse de
+                // IllegalStateException) quando um FGS é iniciado DE BACKGROUND sem uma
+                // exceção de background-start válida. O fix do 3.4.4 só cobria a
+                // SecurityException (falta de permissão), lançada dentro do onStartCommand;
+                // este caso é lançado já aqui, no startForegroundService. Sem o FGS o scan
+                // em background segue via o PendingIntent scan, então não vale crashar.
+                Log.w(TAG, "FGS start blocked (started from background) — skipping instead of crashing", e)
+            } catch (e: Exception) {
+                Log.w(TAG, "Could not start foreground service — skipping", e)
             }
         }
 
@@ -83,10 +95,16 @@ class BeaconScanService : Service() {
                 putExtra(EXTRA_TEXT, text)
                 putExtra(EXTRA_UPDATE_ONLY, true)
             }
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                context.startForegroundService(intent)
-            } else {
-                context.startService(intent)
+            try {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                    context.startForegroundService(intent)
+                } else {
+                    context.startService(intent)
+                }
+            } catch (e: Exception) {
+                // Mesma proteção do start(): não crashar se o SO recusar (re)iniciar o FGS
+                // de background (ForegroundServiceStartNotAllowed / SecurityException).
+                Log.w(TAG, "Could not update foreground service notification — skipping", e)
             }
         }
 


### PR DESCRIPTION
## 3.4.5 — endurece start do FGS + exige `BLUETOOTH_SCAN` no Android 12+

Fecha os dois pontos que sobraram do 3.4.4, ambos observados no teste de 4 cenários de permissão no Car Media (Samsung A55 / Android 16). **0 crashes** nos 4 cenários.

### 1. Segundo modo de crash do Foreground Service
`BeaconScanService.start()` chamava `startForegroundService()` sem proteção. No Android 14+, quando o serviço é iniciado **de background** (ex.: Watchdog / `BOOT_COMPLETED`), o SO lança `ForegroundServiceStartNotAllowedException` (subclasse de `IllegalStateException`) já em `startForegroundService()` — **antes** do `onStartCommand`, onde ficava o try/catch do 3.4.4 (que só cobria a `SecurityException` de permissão).

- `start()` e `updateNotification()` agora envolvem `startForegroundService()` em try/catch.
- Sem o FGS, o scan em background continua via o PendingIntent scan (0xBEAD) — não vale crashar.

### 2. `checkPermissions()` alinhado ao gate real do SO no 12+
Era `location || bluetoothScan`. No Android 12+ (manifest com `neverForLocation`), **só `BLUETOOTH_SCAN`** destrava o scan — location sozinho fazia o SDK tentar um scan que o SO bloqueava com `SecurityException` (capturada), poluindo o log sem detectar nada.

- `BeaconManager` e `BluetoothManager`: no 12+ exigem `BLUETOOTH_SCAN` direto; no <12 mantêm o modelo legado (`FINE`/`COARSE`).
- `BackgroundScanManager.enableBackgroundScanning()`: early-return se falta `BLUETOOTH_SCAN` no 12+ (o path `restartScanningFromBackground` era ungated).

### Resultado do teste de 4 cenários (A55 / Android 16)
`Location+BT` / `só Location` / `só BT` / `nenhum` → **0 crashes**. Detecta em `BT+Location` e `só-BT`. "Só location" não detecta em background por design do SO (documentado; sem valor real fora de foreground).

### Validação
- `./gradlew :sdk:assemble` + `publishToMavenLocal` OK (AAR 3.4.5 em `mavenLocal`).
- ⚠️ **Draft — não mergear ainda**: aguardando validação final no device (A55) antes do release.

Após merge: `git tag v3.4.5 && git push origin v3.4.5` → JitPack.
