### PR TITLE
release: v3.4.6 — alinhamento de versão

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Never-crash-the-host hardening.** Two synchronous crash vectors reachable from the host were closed: (1) `BluetoothManager` cast the Bluetooth system service non-null — on devices without a Bluetooth radio (some emulators, Android TV/Auto, Wi-Fi-only tablets; the SDK declares `bluetooth_le` as `required=false` on purpose) the host's very first `getInstance()` call would NPE. Now a safe cast + try/catch: no radio → the SDK stays idle. (2) `configure()` threw `IllegalArgumentException` on a blank business token — a host wired to an empty BuildConfig field would crash on startup. Now a safe no-op: logged, reported to error telemetry, surfaced via `onError`, SDK stays unconfigured. Doctrine: the SDK may fail silently, but it must NEVER crash the host — and every silent failure is reported to `POST /sdk-errors`.
 
+## [3.4.6] - 2026-07-14
+
+- chore(release): alinha versão 3.4.6 (version-only; sem mudança funcional — o fix de scan BLE 3.4.6 é iOS-only, o Android já filtra por Service Data)
+
 ## [3.4.5] - 2026-07-03
 
 ### Fixed

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,4 +10,4 @@ org.gradle.configureondemand=true
 # SDK Metadata
 SDK_GROUP_ID=com.github.Bearound
 SDK_ARTIFACT_ID=bearound-android-sdk
-SDK_VERSION=3.4.5
+SDK_VERSION=3.4.6


### PR DESCRIPTION
Bump **version-only** do SDK Android: `SDK_VERSION` 3.4.5 → 3.4.6, sem nenhuma mudança de código.

## Por quê
O fix de scan BLE da rodada 3.4.6 é **iOS-only** — no iOS o scan filtrava por Service UUID enquanto o `0xBEAD` vive no Service **Data**; o Android nunca teve esse bug porque já filtra por `setServiceData`. Este bump serve apenas pra manter o **lockstep de versão** com iOS/Flutter/RN, cujos wrappers pinam `bearound-android-sdk:v3.4.6`.

## Mudanças
- `gradle.properties`: `SDK_VERSION=3.4.5` → `3.4.6`
- `CHANGELOG.md`: entrada `## [3.4.6]` (bullet de release; sem mudança funcional)

## ⚠️ Ao mergear
**Criar a tag `v3.4.6`** no commit de merge — o JitPack resolve os wrappers (iOS/Flutter/RN pinam `v3.4.6`) a partir dessa tag. Sem a tag, os wrappers não conseguem resolver a dependência Android.

## Nota pro release owner
O `CHANGELOG.md` de `main` já continha um bloco `## [Unreleased]` com conteúdo real ("Never-crash-the-host hardening") que **não** foi promovido para `[3.4.6]` (este PR é version-only por instrução). Esse código entra no artefato buildado sob a tag `v3.4.6`; se quiser vê-lo documentado sob `[3.4.6]`, promova o bloco antes de taggear.

---
**Não mergear automaticamente** — aguardando revisão.
