### PR TITLE
release: v3.5.0 — silent-push wake-up + never-crash hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.5.0] - 2026-07-14
+
 ### Added
 
 - **Silent-push wake-up (FCM).** The backend can now trigger an on-demand scan + sync by sending a data-only, high-priority FCM message — the Android counterpart of the iOS silent push. New `BeAroundSDK.handleRemoteMessage(data): Boolean` (returns `true` only for Bearound wake-ups, marked `bearound`; third-party pushes pass through untouched) plus an optional `io.bearound.sdk.push.BearoundMessagingService` the host registers in its manifest (or forwards to from its own `FirebaseMessagingService`). On a wake-up the SDK restores config if the app was killed, restarts scanning (always — a backend wake-up overrides a previous `stopScanning()`) and flushes pending sync. Not auto-registered in the SDK manifest (`firebase-messaging` stays `compileOnly`, so auto-registering would crash apps without Firebase). See README → *Push notifications (FCM) → Silent-push wake-up*.

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,4 +10,4 @@ org.gradle.configureondemand=true
 # SDK Metadata
 SDK_GROUP_ID=com.github.Bearound
 SDK_ARTIFACT_ID=bearound-android-sdk
-SDK_VERSION=3.4.5
+SDK_VERSION=3.5.0


### PR DESCRIPTION
Corta a **3.5.0** (minor — a release leva a feature de silent-push wake-up, testada em device Samsung A16/Android 15, + os dois fixes never-crash). CHANGELOG promovido de [Unreleased] → [3.5.0]. **Ao mergear: rodar o workflow `gradle-publish` (workflow_dispatch)** — ele lê o SDK_VERSION, cria a tag `v3.5.0` e publica (JitPack + GitHub Packages). Substitui o #59 (3.4.6, version-only — fechado como superseded).