### PR TITLE
fix: confiabilidade de scan no Android moderno + beacons fantasma + precision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [3.5.0] - 2026-07-14
+## [3.5.1] - 2026-07-22
+
+### Fixed
+
+- **Ghost beacons on the host list ("beacon shown that is no longer detected").** Two independent causes, both closed: (1) `BeaconManager`'s periodic cleanup evicted timed-out beacons from the internal map but **never emitted** `onBeaconsUpdated` — the host only learned about the change when some *other* beacon delivered a packet, and with no beacons on the air the list froze forever. The cleanup tick now emits the post-expiry snapshot (**including the empty list** — that is how the host learns the last beacon is gone) and refreshes the per-beacon `isStale` flags in the map, so fade-in/out reaches the UI within one 2 s tick. (2) The SDK-level `collectedBeacons` accumulator was emitted whole by the metadata-scan and post-sync listener paths, resurfacing beacons long gone from the air. Those emissions are now TTL-filtered (same clock as the manager's eviction timeout) — the map itself stays intact as the **sync buffer**, so unsynced detections are never dropped. Validated on device (realme C61/Android 14): radio-off test logs `Beacon 0.199 expired` and the UI list clears at the timeout; radio back on → beacons return.
+- **Scan precision (HIGH/MEDIUM/LOW) appeared not to apply.** Applying settings goes through `stopScanning()` + `startScanning()` — and the stop persisted `inZone=false`, so the next start skipped ranging (`startRanging skipped — not inside beacon region`) until a PendingIntent broadcast happened to revive it. With a beacon right next to the phone, HIGH stayed dormant. `stopScanning()` now snapshots the TRUE zone state *before* teardown and `startScanning()` restores it, re-arming the active-scan path when the zone is fresh (within the 5-min exit grace); a genuinely-gone zone still shuts down naturally via the grace. Validated on device: `Zone state fresh — re-arming active scan` logged on both switch directions, and the `LOW_LATENCY` ranging client appears in the Bluetooth stack right after applying HIGH (before the fix, no client was ever registered).
+- **Batch scan was blind to pure-0xBEAD frames (firmware v4 beacons).** Firmware v4 separates the fused advertisement into a pure iBeacon frame and a pure Service Data `0xBEAD` frame (the fix for the Android 14 `neverForLocation` denylist that discarded fused records whole). The slow-beacon batch scan only filtered on the iBeacon frame, so it missed the pure-BEAD half entirely. It now also filters Service Data `0xBEAD`.
+
+### Added
+
+- **Periodic anti-downgrade scan refresh (20 min).** OEMs on Android 13+ silently downgrade long-lived scan sessions (requested BALANCED/LOW_LATENCY demoted to AMBIENT_DISCOVERY/OPPORTUNISTIC — observed in the field on Moto G35 / realme C61, shrinking listening to ~10% duty), and AOSP drops any scan older than 30 min to opportunistic. Every 20 min the SDK now re-registers the metadata and batch scan clients so the platform treats them as fresh sessions at full duty. Budget-aware by construction (`ScanStartBudget`): when there is no start-quota headroom the current session is kept — a tick can only ever be a no-op, never a regression. Also armed on the background revive path (`restartScanningFromBackground`), so a process revived by the watchdog or boot receiver is equally protected. Field-proven: first tick fired at exactly +20:00.000, re-registered both clients in 56 ms, and a beacon delivered and synced 1 s later — zero interruption across a 24-min background soak (60 syncs, no errors).
+
+### Changed
+
+- **PendingIntent filter scan stays armed in the foreground.** It was previously disabled while the app was foregrounded — but on AOSP-like OEMs that denylist fused iBeacon records it is the only delivery path, so disabling it in foreground silenced detection exactly where the user was looking. It is kernel-managed and low-power; keeping it armed costs nothing measurable.
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -133,14 +133,14 @@ allprojects {
 ```kotlin
 // build.gradle.kts
 dependencies {
-    implementation("com.github.Bearound:bearound-android-sdk:v3.5.0")
+    implementation("com.github.Bearound:bearound-android-sdk:v3.5.1")
 }
 ```
 
 ```gradle
 // build.gradle
 dependencies {
-    implementation 'com.github.Bearound:bearound-android-sdk:v3.5.0'
+    implementation 'com.github.Bearound:bearound-android-sdk:v3.5.1'
 }
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,4 +10,4 @@ org.gradle.configureondemand=true
 # SDK Metadata
 SDK_GROUP_ID=com.github.Bearound
 SDK_ARTIFACT_ID=bearound-android-sdk
-SDK_VERSION=3.5.0
+SDK_VERSION=3.5.1

--- a/sdk/src/main/java/io/bearound/sdk/BeAroundSDK.kt
+++ b/sdk/src/main/java/io/bearound/sdk/BeAroundSDK.kt
@@ -56,6 +56,16 @@ import kotlin.math.pow
 class BeAroundSDK private constructor() {
     companion object {
         private const val TAG = "BeAroundSDK"
+
+        /**
+         * Anti-downgrade scan refresh (Fix B, 2026-07). OEMs on Android 13+ silently
+         * downgrade long-lived scan sessions (field-observed: requested BALANCED/LOW_LATENCY
+         * demoted to AMBIENT_DISCOVERY/OPPORTUNISTIC on Moto G35 / realme C61, shrinking
+         * listening to ~10% duty), and AOSP drops any scan older than 30 min to opportunistic.
+         * Re-registering the client restores full duty. 20 min stays safely under the AOSP
+         * 30-min cliff and is far above ScanStartBudget's 4-starts/30 s throttle window.
+         */
+        private const val SCAN_REFRESH_INTERVAL_MS = 20 * 60 * 1000L
         
         @SuppressLint("StaticFieldLeak")
         @Volatile
@@ -88,6 +98,23 @@ class BeAroundSDK private constructor() {
 
     private val metadataCache = mutableMapOf<String, BeaconMetadata>()
     private val collectedBeacons = mutableMapOf<String, Beacon>()
+
+    /**
+     * TTL applied when emitting [collectedBeacons] to the host. The map is ALSO the sync
+     * buffer — unsynced entries must be retained until sent — so expired beacons are
+     * hidden from listener emissions instead of being removed. Kept in step with the
+     * BeaconManager eviction timeout (see startSyncTimer). Without this filter, the
+     * metadata-scan and post-sync emission paths re-surfaced beacons long gone from the
+     * air ("ghost beacons" on the host list).
+     */
+    @Volatile
+    private var listenerBeaconTtlMs: Long = 30_000L
+
+    /** TTL-filtered snapshot of [collectedBeacons] for host emission. Call under [beaconLock]. */
+    private fun collectedForListenerLocked(): List<Beacon> {
+        val cutoff = System.currentTimeMillis() - listenerBeaconTtlMs
+        return collectedBeacons.values.filter { it.timestamp.time >= cutoff }
+    }
     private val beaconLock = ReentrantLock()
 
     // ErrorReporter's handler: SDK coroutine failures are logged + reported, never rethrown.
@@ -120,6 +147,7 @@ class BeAroundSDK private constructor() {
 
     private var syncRunnable: Runnable? = null
     private var dutyCycleRunnable: Runnable? = null
+    private var scanRefreshRunnable: Runnable? = null
 
     private var isSyncing = false
     private lateinit var offlineBatchStorage: OfflineBatchStorage
@@ -319,7 +347,7 @@ class BeAroundSDK private constructor() {
                         beacon
                     }
                     collectedBeacons[beacon.identifier] = updated
-                    collectedBeacons.values.toList()
+                    collectedForListenerLocked()
                 }
 
                 dispatchToListener { it.onBeaconsUpdated(beaconsForListener) }
@@ -353,7 +381,14 @@ class BeAroundSDK private constructor() {
         isInBackground = false
         Log.d(TAG, "App foregrounded")
 
-        backgroundScanManager.disableBackgroundScanning()
+        // O scan por PendingIntent fica ATIVO também em foreground (antes era desligado
+        // aqui). Motivo (campo, 2026-07-21): nos Android 14 AOSP-like (Moto stock, realme
+        // ColorOS) o enforcement do neverForLocation filtra os frames de beacon de TODOS
+        // os scanners regulares — o caminho de broadcast/PendingIntent é o único que
+        // entrega. Desligá-lo em foreground deixava esses aparelhos praticamente cegos
+        // exatamente com o app em uso. Custo: é o mesmo scan filtrado de baixo consumo
+        // que já roda o dia inteiro em background; o kernel deduplica o trabalho de rádio
+        // com os scanners regulares ativos.
 
         if (BeaconScanService.isRunning) {
             BeaconScanService.stop(context)
@@ -735,6 +770,9 @@ class BeAroundSDK private constructor() {
         // Equivalent in spirit to iOS's CLBeaconRegion monitoring.
         backgroundScanManager.enableBackgroundScanning()
 
+        // Fix B — keep long-lived scan sessions at full duty (anti-downgrade re-register).
+        startScanRefreshTimer()
+
         // Persist scanning state for recovery after kill/reboot
         SDKConfigStorage.saveScanningEnabled(context, true)
 
@@ -831,6 +869,7 @@ class BeAroundSDK private constructor() {
         backgroundScanManager.disableBackgroundScanning()
         backgroundScheduler.disableAll()
         stopSyncTimer()
+        stopScanRefreshTimer()
 
         if (BeaconScanService.isRunning) {
             BeaconScanService.stop(context)
@@ -964,6 +1003,9 @@ class BeAroundSDK private constructor() {
         // Adaptive beacon timeout: cover scan + pause + 5s buffer so beacons don't expire mid-duty-cycle
         val beaconTimeout = config.precisionScanDuration + config.precisionPauseDuration + 5_000L
         beaconManager.setBeaconTimeout(beaconTimeout)
+        // Listener emissions of collectedBeacons expire on the same clock as the manager
+        // (setBeaconTimeout clamps to its 30s floor — mirror that so the two lists agree).
+        listenerBeaconTtlMs = maxOf(beaconTimeout, 30_000L)
         Log.d(TAG, "Beacon timeout set to ${beaconTimeout}ms")
 
         when (config.scanPrecision) {
@@ -1068,6 +1110,37 @@ class BeAroundSDK private constructor() {
         dutyCycleRunnable = null
     }
 
+    /**
+     * Fix B — periodic anti-downgrade refresh (see [SCAN_REFRESH_INTERVAL_MS]).
+     *
+     * Every tick re-registers the two long-lived scan clients so the platform treats them
+     * as fresh sessions at full duty:
+     *  - [BluetoothManager.restartScanning] — the metadata (BALANCED) scan;
+     *  - [BeaconManager.refreshBatchScan] — the batch scan.
+     * Both are budget-aware internally (ScanStartBudget): when the budget has no headroom
+     * they keep the current session instead of killing it, so a tick can only ever be a
+     * no-op — never a regression. The PendingIntent scan is NOT restarted here: it is
+     * kernel-managed, exempt from session downgrade, and re-arming it costs budget.
+     */
+    private fun startScanRefreshTimer() {
+        stopScanRefreshTimer()
+        scanRefreshRunnable = object : Runnable {
+            override fun run() {
+                Log.d(TAG, "Scan refresh tick — re-registering scan sessions (anti-downgrade)")
+                bluetoothManager.restartScanning()
+                beaconManager.refreshBatchScan()
+                handler.postDelayed(this, SCAN_REFRESH_INTERVAL_MS)
+            }
+        }
+        handler.postDelayed(scanRefreshRunnable!!, SCAN_REFRESH_INTERVAL_MS)
+        Log.d(TAG, "Scan refresh timer armed (every ${SCAN_REFRESH_INTERVAL_MS / 60000} min)")
+    }
+
+    private fun stopScanRefreshTimer() {
+        scanRefreshRunnable?.let { handler.removeCallbacks(it) }
+        scanRefreshRunnable = null
+    }
+
     private fun syncBeacons(forceBackground: Boolean = false) {
         scope.launch {
             if (isSyncing) return@launch
@@ -1149,9 +1222,10 @@ class BeAroundSDK private constructor() {
                         }
                         Log.d(TAG, "Marked ${syncedIds.size} beacons as synced")
 
-                        // Notify listener so UI reflects sync state
+                        // Notify listener so UI reflects sync state (TTL-filtered: beacons
+                        // already gone from the air must not resurface here)
                         val updatedBeacons = beaconLock.withLock {
-                            collectedBeacons.values.toList()
+                            collectedForListenerLocked()
                         }
                         dispatchToListener { it.onBeaconsUpdated(updatedBeacons) }
 
@@ -1414,13 +1488,19 @@ class BeAroundSDK private constructor() {
         
         // Scanning mode is automatic based on app state
         beaconManager.startScanning()
-        
+
         // Re-enable background mechanisms
         backgroundScanManager.enableBackgroundScanning()
         backgroundScheduler.enableAll()
-        
+
         // Bluetooth scanning is always enabled in v2.2.0+
         bluetoothManager.startScanning()
+
+        // Fix B — this revive path starts the same long-lived scan sessions as
+        // startScanning(), so it needs the same anti-downgrade refresh. Without this,
+        // a process revived by the watchdog/boot receiver ran unprotected until the
+        // host happened to call startScanning() again.
+        startScanRefreshTimer()
 
         // Restore foreground service if it was enabled
         val fgConfig = foregroundScanConfig

--- a/sdk/src/main/java/io/bearound/sdk/BeaconManager.kt
+++ b/sdk/src/main/java/io/bearound/sdk/BeaconManager.kt
@@ -359,6 +359,22 @@ class BeaconManager(private val context: Context) {
             isScanning = true
             onScanningStateChanged?.invoke(true)
 
+            // Reconfig-safe zone restore: a stop()+start() cycle (settings apply) must not
+            // lose a live in-zone state. Restores the snapshot persisted by stopScanning()
+            // and — when the last advert is fresh (within the exit grace) — re-fires the
+            // active-scan path the rising edge would normally fire, so HIGH precision
+            // starts ranging immediately instead of waiting for the next broadcast.
+            // If the zone is genuinely gone, the exit grace shuts active scanning down.
+            restorePersistedZoneState()
+            val last = lastBeaconSeenAt
+            if (isInBeaconRegion && last != null &&
+                System.currentTimeMillis() - last < ZONE_EXIT_GRACE_MS
+            ) {
+                Log.d(TAG, "Zone state fresh (${(System.currentTimeMillis() - last) / 1000}s since last ad) — re-arming active scan")
+                startRegionCleanupTimer()
+                onActiveScanShouldStart?.invoke()
+            }
+
         } catch (e: Exception) {
             Log.e(TAG, "Failed to start scanning: ${e.message}")
             io.bearound.sdk.telemetry.ErrorReporter.report(e, "BeaconManager.startScanning")
@@ -384,6 +400,14 @@ class BeaconManager(private val context: Context) {
         }
         stopSlowBeaconBatchScan()
 
+        // Snapshot the TRUE zone state BEFORE tearing it down. stop()+start() is also the
+        // reconfigure path (settings apply): persisting `false` here made the next start
+        // skip ranging ("startRanging skipped — not inside beacon region") until a
+        // PendingIntent broadcast happened to revive it — in the field, precision changes
+        // looked like they didn't apply (realme C61, 2026-07-22). The fresh snapshot lets
+        // startScanning() restore the zone and re-arm active scanning immediately.
+        persistZoneState()
+
         beaconLock.withLock {
             detectedBeacons.clear()
             beaconLastSeen.clear()
@@ -394,7 +418,6 @@ class BeaconManager(private val context: Context) {
         lastBeaconSeenAt = null
 
         isInBeaconRegion = false
-        persistZoneState()
         emptyBeaconCount = 0
         isScanning = false
         onScanningStateChanged?.invoke(false)
@@ -536,12 +559,20 @@ class BeaconManager(private val context: Context) {
                     IBeaconParser.BEAROUND_IBEACON_MASK
                 )
                 .build()
+            // fw v4+ transmite o 0xBEAD como advertisement PRIMÁRIO (fase alternada) —
+            // o filtro offloaded de service data agora casa. Sem ele o batch é CEGO pros
+            // frames BEAD-puros (validado em campo 2026-07-21: o batch via filtro iBeacon
+            // não enxergava a fase B do fw v4). Lista de filtros = OR: cobre beacons
+            // antigos (iBeacon no primário) E novos (0xBEAD no primário).
+            val beadFilter = ScanFilter.Builder()
+                .setServiceData(IBeaconParser.BEAD_SERVICE_UUID, byteArrayOf(), byteArrayOf())
+                .build()
             val settings = ScanSettings.Builder()
                 .setScanMode(ScanSettings.SCAN_MODE_LOW_LATENCY)
                 .setCallbackType(ScanSettings.CALLBACK_TYPE_ALL_MATCHES)
                 .setReportDelay(SLOW_BEACON_BATCH_DELAY_MS)
                 .build()
-            scanner.startScan(listOf(ibFilter), settings, batchScanCallback)
+            scanner.startScan(listOf(ibFilter, beadFilter), settings, batchScanCallback)
             isBatchScanning = true
             lastBatchDeliveryAt = System.currentTimeMillis() // liveness baseline
             Log.d(TAG, "Slow-beacon batch scan started (reportDelay=${SLOW_BEACON_BATCH_DELAY_MS}ms)")
@@ -662,14 +693,9 @@ class BeaconManager(private val context: Context) {
 
         cleanupExpiredBeacons()
 
-        // Refresh stale flag for every beacon in the snapshot — emit reflects current freshness
-        val currentBeacons = beaconLock.withLock {
-            detectedBeacons.values.map { b ->
-                val lastSeen = beaconLastSeen[b.identifier] ?: now
-                val staleNow = (now - lastSeen) > STALE_THRESHOLD_MS
-                if (staleNow != b.isStale) b.copy(isStale = staleNow) else b
-            }
-        }
+        // Refresh stale flag for every beacon — emit reflects current freshness
+        refreshStaleFlags(now)
+        val currentBeacons = beaconLock.withLock { detectedBeacons.values.toList() }
 
         if (currentBeacons.isNotEmpty()) {
             onBeaconsUpdated?.invoke(currentBeacons)
@@ -678,7 +704,29 @@ class BeaconManager(private val context: Context) {
         startWatchdog()
     }
 
-    private fun cleanupExpiredBeacons() {
+    /**
+     * Recomputes the per-beacon staleness flag IN the detected map. Returns true when any
+     * flag flipped since the last pass — the periodic cleanup uses this to know the host's
+     * list needs a refresh (fade-in/fade-out) without spamming identical emissions.
+     */
+    private fun refreshStaleFlags(now: Long = System.currentTimeMillis()): Boolean =
+        beaconLock.withLock {
+            var changed = false
+            for (id in detectedBeacons.keys.toList()) {
+                val b = detectedBeacons[id] ?: continue
+                val lastSeen = beaconLastSeen[id] ?: now
+                val staleNow = (now - lastSeen) > STALE_THRESHOLD_MS
+                if (staleNow != b.isStale) {
+                    detectedBeacons[id] = b.copy(isStale = staleNow)
+                    changed = true
+                }
+            }
+            changed
+        }
+
+    /** Removes timed-out beacons from the detected map. Returns true when any was removed. */
+    private fun cleanupExpiredBeacons(): Boolean {
+        var removedAny = false
         val (hadBeaconsBefore, hasBeaconsAfter) = beaconLock.withLock {
             val before = detectedBeacons.isNotEmpty()
             val now = System.currentTimeMillis()
@@ -693,6 +741,7 @@ class BeaconManager(private val context: Context) {
                 rssiFilter.remove(key)
                 rssiAccumulators.remove(key)
             }
+            removedAny = expiredKeys.isNotEmpty()
             Pair(before, detectedBeacons.isNotEmpty())
         }
 
@@ -718,6 +767,7 @@ class BeaconManager(private val context: Context) {
                 Log.d(TAG, "Detected map drained but zone-exit grace not yet elapsed (${sinceLast}s since last ad, grace=${ZONE_EXIT_GRACE_MS / 1000}s) — staying in region")
             }
         }
+        return removedAny
     }
 
     private fun startRegionCleanupTimer() {
@@ -728,7 +778,17 @@ class BeaconManager(private val context: Context) {
                     stopRegionCleanupTimer()
                     return
                 }
-                cleanupExpiredBeacons()
+                val removed = cleanupExpiredBeacons()
+                val staleChanged = refreshStaleFlags()
+                if (removed || staleChanged) {
+                    // Push the post-expiry snapshot (possibly EMPTY) to the host. Without
+                    // this emit, a beacon that left the air stayed frozen on the host's
+                    // list until the next packet from any OTHER beacon arrived — the
+                    // "ghost beacon" seen in the example app. An empty list is a valid
+                    // emission: it is how the host learns the last beacon is gone.
+                    val snapshot = beaconLock.withLock { detectedBeacons.values.toList() }
+                    onBeaconsUpdated?.invoke(snapshot)
+                }
                 if (regionCleanupRunnable != null) {
                     handler.postDelayed(this, REGION_CLEANUP_INTERVAL_MS)
                 }
@@ -789,6 +849,17 @@ class BeaconManager(private val context: Context) {
     private fun stopRangingRefreshTimer() {
         rangingRefreshRunnable?.let { handler.removeCallbacks(it) }
         rangingRefreshRunnable = null
+    }
+
+    /**
+     * Re-registra o batch scan (anti-downgrade) — par do BluetoothManager.restartScanning().
+     * Se o ScanStartBudget negar o re-start, isBatchScanning fica false e o próprio
+     * watchdog ([checkRangingHealth]) re-arma no próximo ciclo — sem estado perdido.
+     */
+    fun refreshBatchScan() {
+        if (!isScanning || !isBatchScanning) return
+        stopSlowBeaconBatchScan()
+        startSlowBeaconBatchScan()
     }
 
     private fun checkRangingHealth() {

--- a/sdk/src/main/java/io/bearound/sdk/BluetoothManager.kt
+++ b/sdk/src/main/java/io/bearound/sdk/BluetoothManager.kt
@@ -129,6 +129,38 @@ class BluetoothManager(private val context: Context) {
         }
     }
 
+    /**
+     * Re-registra o scan de metadata (stop+start) SEM mudar o estado do ciclo de vida.
+     * Anti-downgrade: sessões de scan longas são rebaixadas pelo sistema (AOSP: >30 min
+     * vira opportunistic; OEMs Android 13+ aplicam adaptive throttling antes disso —
+     * sessões AMBIENT_DISCOVERY/OPPORTUNISTIC observadas em campo no Moto G35/realme C61).
+     * Uma sessão recém-registrada volta ao duty pleno. Chamado pelo refresh periódico do
+     * SDK (~20 min). Se o ScanStartBudget não tiver folga, mantém a sessão atual como
+     * está (pular um refresh é inofensivo; matar o scan sem conseguir religar não é).
+     */
+    @SuppressLint("MissingPermission")
+    fun restartScanning() {
+        if (!isScanning) return
+        if (!checkPermissions()) return
+        if (!ScanStartBudget.tryAcquire("metadata-restart")) return
+        try {
+            bluetoothLeScanner?.stopScan(scanCallback)
+        } catch (_: Exception) {
+            /* sessão já morta no stack — o start abaixo recria */
+        }
+        try {
+            val settings = ScanSettings.Builder()
+                .setScanMode(ScanSettings.SCAN_MODE_BALANCED)
+                .setReportDelay(0)
+                .build()
+            bluetoothLeScanner?.startScan(metadataScanFilters(), settings, scanCallback)
+            Log.d(TAG, "Metadata scan re-registered (anti-downgrade refresh)")
+        } catch (e: Exception) {
+            isScanning = false
+            Log.w(TAG, "Anti-downgrade restart failed: ${e.message}")
+        }
+    }
+
     @SuppressLint("MissingPermission")
     fun stopScanning() {
         if (!isScanning) return


### PR DESCRIPTION
## O que este PR faz

Três grupos de correções no SDK, todos **validados em bancada** (realme C61 / Android 14, beacon v4 0.199 ao lado), fechando a versão **3.5.1**.

---

### 1️⃣ Confiabilidade de scan no Android 13+ (a outra metade do fix do firmware v4)

| Fix | O que resolve |
|---|---|
| Filtro Service Data 0xBEAD no **batch scan** | Os beacons v4 transmitem frames BEAD **puros** — o filtro só-iBeacon do batch era cego a eles |
| **Refresh anti-downgrade a cada 20 min** | OEMs rebaixam sessões longas de scan (AMBIENT_DISCOVERY/OPPORTUNISTIC observados em campo) e o AOSP rebaixa >30 min para opportunistic. O re-registro devolve o duty pleno. Budget-aware: um tick nunca mata o scan — no máximo vira no-op. Armado também no caminho de revive pós-morte de processo (`restartScanningFromBackground`) |
| **PendingIntent sempre armado** (inclusive foreground) | É o único caminho de entrega nos OEMs que descartam records fundidos com iBeacon |

**Prova de campo:** primeiro tick disparou em exatamente +20:00.000, re-registrou os 2 clients em 56 ms, e um beacon foi processado e sincado 1 s depois — zero interrupção. 60 syncs contínuos em 24 min de background no C61.

### 2️⃣ Beacons fantasma na lista do host ("fica beacon que não foi detectado")

Causa dupla:
- `cleanupExpiredBeacons()` removia do mapa interno mas **nunca emitia** `onBeaconsUpdated` — o host só ficava sabendo quando OUTRO beacon entregava pacote. Sem nenhum beacon no ar, a lista congelava para sempre. Agora o cleanup emite o snapshot pós-expiração (**inclusive vazio**) e refresca as flags `isStale` (o fade da UI passa a acontecer em ≤2 s).
- `collectedBeacons` (o acumulador do SDK) era emitido inteiro pelos caminhos do metadata-scan e pós-sync, **ressuscitando** beacons já fora do ar. As emissões agora são filtradas por TTL — **o mapa continua intacto como buffer de sync** (detecções não-sincadas jamais são descartadas: eventos preservados).

**Prova de campo:** teste BT-off → `Beacon 0.199 expired` + `0.82 expired` nos logs → lista limpa na UI; BT-on → beacons voltam (sync `2 beacon(s) Sucesso`).

### 3️⃣ Precision (HIGH/MEDIUM/LOW) parecia não aplicar

O apply de configurações faz `stop()+start()` — e o `stopScanning()` persistia `inZone=false`, então o start seguinte **pulava o ranging** (`startRanging skipped — not inside beacon region`) até um broadcast reviver por acaso. Com beacon do lado, HIGH ficava dormente.

Fix: `stopScanning()` agora fotografa o estado REAL da zona **antes** do teardown, e `startScanning()` restaura + re-arma o caminho de active-scan quando a zona é fresca (< exit grace de 5 min). Zona genuinamente abandonada se desliga sozinha pelo grace.

**Prova de campo:** `Zone state fresh (21s since last ad) — re-arming active scan` nas duas direções de troca; client **LOW_LATENCY** registrado no stack BT após aplicar HIGH (antes do fix, nenhum client subia).

---

### Validação
- ✅ Testes unitários do SDK verdes
- ✅ HIGH→MEDIUM→HIGH ao vivo no C61 com logs de re-arm nas duas trocas
- ✅ Ghost test (BT off/on) limpa e restaura a lista
- ✅ Soak de 24 min em background: 60 syncs, zero erros

### Pós-merge (trem 3.5.1)
Flutter e RN **não mudam código** — só bump do pin `com.github.Bearound:bearound-android-sdk:v3.5.0 → v3.5.1` nos `android/build.gradle` + release de cada wrapper. iOS não é afetado.