### PR TITLE
fix(example): UI honesta com Bluetooth desligado + atalho para ligar

### DIFF
--- a/BearoundScan/src/main/java/io/bearound/bearoundscan/ui/ContentScreen.kt
+++ b/BearoundScan/src/main/java/io/bearound/bearoundscan/ui/ContentScreen.kt
@@ -278,6 +278,7 @@ fun ContentScreen(viewModel: BeaconViewModel = viewModel(), paddingValues: Paddi
 
 @Composable
 fun PermissionsCard(state: BeAroundScanState) {
+    val context = LocalContext.current
     Card(
         modifier = Modifier.fillMaxWidth(),
         colors = CardDefaults.cardColors(
@@ -307,6 +308,29 @@ fun PermissionsCard(state: BeAroundScanState) {
                 value = state.bluetoothStatus,
                 color = getBluetoothColor(state.bluetoothStatus)
             )
+
+            // Radio off = no detection at all. Offer the fix instead of pretending to scan.
+            // System Bluetooth panel (no extra permission — ACTION_REQUEST_ENABLE would
+            // need BLUETOOTH_CONNECT, which this test app deliberately does not declare).
+            if (state.bluetoothStatus == "Desligado") {
+                Button(
+                    onClick = {
+                        context.startActivity(Intent(Settings.ACTION_BLUETOOTH_SETTINGS))
+                    },
+                    modifier = Modifier.fillMaxWidth(),
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = MaterialTheme.colorScheme.error
+                    )
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Bluetooth,
+                        contentDescription = null,
+                        modifier = Modifier.size(18.dp)
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text("Bluetooth desligado — toque para ligar")
+                }
+            }
 
             PermissionRow(
                 icon = Icons.Default.Notifications,

--- a/BearoundScan/src/main/java/io/bearound/bearoundscan/viewmodel/BeaconViewModel.kt
+++ b/BearoundScan/src/main/java/io/bearound/bearoundscan/viewmodel/BeaconViewModel.kt
@@ -2,8 +2,12 @@ package io.bearound.bearoundscan.viewmodel
 
 import android.Manifest
 import android.app.Application
+import android.bluetooth.BluetoothAdapter
 import android.bluetooth.BluetoothManager
+import android.content.BroadcastReceiver
 import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
 import android.content.SharedPreferences
 import android.content.pm.PackageManager
 import android.location.LocationManager
@@ -110,6 +114,24 @@ class BeaconViewModel(application: Application) : AndroidViewModel(application),
 
     private val maxLogEntries = 50000
 
+    /**
+     * Live Bluetooth adapter state → keeps the permissions card AND the status line honest.
+     * Without this, the UI said "Scaneando..." with the radio off (bench bug, Redmi 9) and
+     * the "Desligado" row only refreshed on the next permission prompt.
+     */
+    private val bluetoothStateReceiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context?, intent: Intent?) {
+            if (intent?.action != BluetoothAdapter.ACTION_STATE_CHANGED) return
+            checkBluetoothStatus()
+            val isOn = intent.getIntExtra(BluetoothAdapter.EXTRA_STATE, -1) == BluetoothAdapter.STATE_ON
+            if (_state.value.isScanning) {
+                _state.value = _state.value.copy(
+                    statusMessage = if (isOn) "Scaneando..." else "Bluetooth desligado"
+                )
+            }
+        }
+    }
+
     init {
         previousListener = sdk.listener
         sdk.listener = this
@@ -118,6 +140,11 @@ class BeaconViewModel(application: Application) : AndroidViewModel(application),
         updatePermissionStatus()
         checkBluetoothStatus()
         checkNotificationStatus()
+
+        getApplication<Application>().registerReceiver(
+            bluetoothStateReceiver,
+            IntentFilter(BluetoothAdapter.ACTION_STATE_CHANGED)
+        )
 
         configureSDK(
             _state.value.scanPrecision,
@@ -129,6 +156,7 @@ class BeaconViewModel(application: Application) : AndroidViewModel(application),
 
     override fun onCleared() {
         super.onCleared()
+        runCatching { getApplication<Application>().unregisterReceiver(bluetoothStateReceiver) }
         sdk.listener = previousListener
     }
 
@@ -221,9 +249,14 @@ class BeaconViewModel(application: Application) : AndroidViewModel(application),
         scanStartTime = Date()
         wasInBeaconRegion = false
 
+        // Honest status: with the radio off nothing is being scanned — say so instead of
+        // "Scaneando..." (the SDK stays armed and resumes by itself when Bluetooth returns).
+        val btOn = (getApplication<Application>().getSystemService(Context.BLUETOOTH_SERVICE)
+            as? BluetoothManager)?.adapter?.isEnabled == true
+
         _state.value = _state.value.copy(
             isScanning = true,
-            statusMessage = "Scaneando...",
+            statusMessage = if (btOn) "Scaneando..." else "Bluetooth desligado",
             lastScanTime = Date(),
             // Reset geofence counters for a fresh debug session
             geofenceEvents = emptyList(),


### PR DESCRIPTION
## O que este PR faz

Corrige o bug de bancada conhecido desde o teste do Redmi 9 (2026-07-09) e nunca commitado: **com o Bluetooth desligado, o app dizia "Scaneando..."** e a linha "Bluetooth" do painel só atualizava no próximo prompt de permissão.

### Mudanças (só no app de teste — zero mudança no SDK)

1. **Receiver ao vivo** de `BluetoothAdapter.ACTION_STATE_CHANGED` — o painel de permissões e a linha de status refletem o rádio em tempo real
2. **Status honesto**: com o rádio off, o status mostra "Bluetooth desligado" em vez de fingir scan (o SDK continua armado e retoma sozinho quando o BT volta — comportamento já validado: `Bluetooth restored — re-arming batch scan`)
3. **Botão de 1 toque** na linha "Desligado" abrindo o painel Bluetooth do sistema

> Decisão: `ACTION_BLUETOOTH_SETTINGS` e **não** `ACTION_REQUEST_ENABLE` — o request-enable exigiria adicionar `BLUETOOTH_CONNECT` ao manifest, mudando o perfil de permissões que este app de teste existe para exercitar (matriz da bancada).

### Validação (realme C61)
- Rádio off → linha vermelha "Desligado" + botão aparece (ao vivo, sem reabrir o app)
- Toque → painel do sistema abre
- Rádio on → linha vira "Ligado", botão some, scan retoma sozinho

| BT off | 
|---|
| linha "Desligado" em vermelho + botão "Bluetooth desligado — toque para ligar" |