### PR TITLE
fix(example): BearoundScan roda no API 23+ (piso da bancada: Galaxy S7)

### DIFF
--- a/BearoundScan/build.gradle
+++ b/BearoundScan/build.gradle
@@ -22,7 +22,7 @@ android {
 
     defaultConfig {
         applicationId = "io.bearound.bearoundscan"
-        minSdk = 26
+        minSdk = 23
         targetSdk = 36
         versionCode = 1
         versionName = "1.0.0"

--- a/BearoundScan/src/main/java/io/bearound/bearoundscan/notification/BeaconNotificationManager.kt
+++ b/BearoundScan/src/main/java/io/bearound/bearoundscan/notification/BeaconNotificationManager.kt
@@ -55,6 +55,9 @@ class BeaconNotificationManager(private val context: Context) {
     }
 
     private fun createNotificationChannel() {
+        // Channels exist only on API 26+ — on older devices (bench floor: Galaxy S7 / API 23)
+        // notifications go out channel-less.
+        if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.O) return
         val channel = NotificationChannel(
             CHANNEL_ID,
             CHANNEL_NAME,

--- a/BearoundScan/src/main/res/mipmap/ic_launcher.xml
+++ b/BearoundScan/src/main/res/mipmap/ic_launcher.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?><!-- Pre-API-26 fallback: same vectors as the adaptive icon -->
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@drawable/ic_launcher_background" />
+    <item android:drawable="@drawable/ic_launcher_foreground" />
+</layer-list>

--- a/BearoundScan/src/main/res/mipmap/ic_launcher_round.xml
+++ b/BearoundScan/src/main/res/mipmap/ic_launcher_round.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?><!-- Pre-API-26 fallback: same vectors as the adaptive icon -->
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@drawable/ic_launcher_background" />
+    <item android:drawable="@drawable/ic_launcher_foreground" />
+</layer-list>


### PR DESCRIPTION
O BearoundScan é o app canônico da bancada, mas o `minSdk 26` deixava o device mais antigo da matriz (Galaxy S7 / Android 6 / API 23) preso no módulo legado `:app`. O SDK já suporta `minSdk 23` — só o app bloqueava.

**Mudanças (3):**
1. `minSdk 26 → 23`
2. Guard no `NotificationChannel` (API 26+; abaixo disso as notificações saem sem canal)
3. Ícone de launcher fallback pré-26 (layer-list com os mesmos vectors do adaptive icon — o res só tinha `mipmap-anydpi-v26`)

**Validado em device:** instalado e rodando nos 4 da bancada — **Galaxy S7 (API 23)**, realme C61, Moto G35 e Galaxy A16. Marcador de boot do SDK 3.5.1 presente e zero crashes nos quatro; `REGION ENTER` disparando no S7.