### PR TITLE
fix(sdk): duty contínuo gerenciado por hardware (MEDIUM/LOW) + self-heal do metadata scan

### DIFF
--- a/BearoundScan/build.gradle
+++ b/BearoundScan/build.gradle
@@ -22,7 +22,7 @@ android {
 
     defaultConfig {
         applicationId = "io.bearound.bearoundscan"
-        minSdk = 26
+        minSdk = 23
         targetSdk = 36
         versionCode = 1
         versionName = "1.0.0"

--- a/BearoundScan/src/main/java/io/bearound/bearoundscan/notification/BeaconNotificationManager.kt
+++ b/BearoundScan/src/main/java/io/bearound/bearoundscan/notification/BeaconNotificationManager.kt
@@ -55,6 +55,9 @@ class BeaconNotificationManager(private val context: Context) {
     }
 
     private fun createNotificationChannel() {
+        // Channels exist only on API 26+ — on older devices (bench floor: Galaxy S7 / API 23)
+        // notifications go out channel-less.
+        if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.O) return
         val channel = NotificationChannel(
             CHANNEL_ID,
             CHANNEL_NAME,

--- a/BearoundScan/src/main/java/io/bearound/bearoundscan/ui/ContentScreen.kt
+++ b/BearoundScan/src/main/java/io/bearound/bearoundscan/ui/ContentScreen.kt
@@ -379,10 +379,17 @@ fun ScanInfoCard(state: BeAroundScanState, viewModel: BeaconViewModel) {
                 value = state.scanPrecision.name
             )
             InfoRow(label = "Sync:", value = "${state.currentSyncInterval}s")
-            InfoRow(label = "Duração:", value = "${viewModel.scanDuration}s")
-            if (viewModel.pauseDuration > 0) {
-                InfoRow(label = "Pausa:", value = "${viewModel.pauseDuration}s")
-            }
+            // Continuous scan modes (SDK 3.5.2): no more manual scan/pause windows — the
+            // controller manages the duty in hardware. While this panel is visible the app
+            // is foregrounded, so listening is always at maximum here.
+            InfoRow(
+                label = "Escuta:",
+                value = when (state.scanPrecision) {
+                    ScanPrecision.HIGH -> "Contínua (máxima)"
+                    ScanPrecision.MEDIUM -> "Máxima em uso; ~20% em 2º plano"
+                    ScanPrecision.LOW -> "Máxima em uso; ~10% em 2º plano"
+                }
+            )
         }
     }
 }

--- a/BearoundScan/src/main/java/io/bearound/bearoundscan/viewmodel/BeaconViewModel.kt
+++ b/BearoundScan/src/main/java/io/bearound/bearoundscan/viewmodel/BeaconViewModel.kt
@@ -125,6 +125,11 @@ class BeaconViewModel(application: Application) : AndroidViewModel(application),
         )
 
         startScanning()
+
+        // Zone card must reflect the SDK's real state: after a reconfigure the zone is
+        // RESTORED (no onEnterBeaconRegion is fired, by design), so initialize from the
+        // property instead of waiting for an edge event that will not come.
+        _state.value = _state.value.copy(isInBeaconRegion = sdk.isInBeaconRegion)
     }
 
     override fun onCleared() {
@@ -471,10 +476,14 @@ class BeaconViewModel(application: Application) : AndroidViewModel(application),
         viewModelScope.launch {
             appendGeofenceEvent(
                 if (isActive) GeofenceEvent.Kind.SCAN_ACTIVE else GeofenceEvent.Kind.SCAN_PAUSED,
-                if (isActive) "Scan ativo (BLE + duty cycle) LIGADO"
+                if (isActive) "Scan ativo (BLE) LIGADO"
                 else "Scan ativo PAUSADO — só PendingIntent scan rodando"
             )
-            _state.value = _state.value.copy(isActiveScanRunning = isActive)
+            _state.value = _state.value.copy(
+                isActiveScanRunning = isActive,
+                // Re-arm path (zone restored) changes region state without an edge event.
+                isInBeaconRegion = sdk.isInBeaconRegion
+            )
         }
     }
 

--- a/BearoundScan/src/main/res/mipmap/ic_launcher.xml
+++ b/BearoundScan/src/main/res/mipmap/ic_launcher.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?><!-- Pre-API-26 fallback: same vectors as the adaptive icon -->
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@drawable/ic_launcher_background" />
+    <item android:drawable="@drawable/ic_launcher_foreground" />
+</layer-list>

--- a/BearoundScan/src/main/res/mipmap/ic_launcher_round.xml
+++ b/BearoundScan/src/main/res/mipmap/ic_launcher_round.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?><!-- Pre-API-26 fallback: same vectors as the adaptive icon -->
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@drawable/ic_launcher_background" />
+    <item android:drawable="@drawable/ic_launcher_foreground" />
+</layer-list>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.5.2] - 2026-07-22
+
+### Changed
+
+- **MEDIUM/LOW precision: ONE continuous scan with a hardware-managed duty cycle.** MEDIUM → `SCAN_MODE_BALANCED` (controller listens ~1 s every ~5 s, ~20% duty); LOW → `SCAN_MODE_LOW_POWER` (~10%). Replaces the manual 10 s-scan/10 s-pause duty cycle, which consumed 3-4 of the 5 scan-starts/30 s the OS allows *by design* — any extra start (watchdog, batch revive, anti-downgrade refresh, fg/bg flip) tripped the quota and the OS silently starved every scanner for 30 s+ (field: Moto G35, "minutes without a beacon" with the duty visibly cycling and zero deliveries). One registration = zero start churn, and beacons no longer expire inside artificial pause windows.
+- **Adaptive foreground boost — best detection automatically, zero config.** In FOREGROUND every precision ranges at `LOW_LATENCY` (the user is looking at the screen; the display dwarfs the radio cost); in BACKGROUND each precision pays its own price (HIGH/MEDIUM → BALANCED, LOW → LOW_POWER). A fg/bg flip re-registers the ranging client with the new mode (budget-aware). This makes MEDIUM a safe plug-and-play default. Field-proof on the bench's weak-receiver device (Moto G35, Unisoc): MEDIUM went from ZERO deliveries to the beacon present in every sync window.
+- **Beacon eviction timeout now matches the continuous modes**: 15 s (HIGH/MEDIUM) / 25 s (LOW), floor 30 s → 10 s. A present beacon delivers every ~1-5 s, so ~3 missed windows evict — the host list stays honest without flickering.
+
+### Fixed
+
+- **Metadata scan self-heals `SCAN_FAILED_ALREADY_STARTED` (code 1).** Stack/SDK registration desync (failed stop, BT cycle) left the metadata scan a zombie until a full app restart. The stale registration is cleared and re-armed once; `ScanStartBudget` is the natural brake against a heal loop.
+
+### Added
+
+- **`BeAroundSDK.isInBeaconRegion`** — lets hosts render zone state correctly after a reconfigure/restart, where the zone is *restored* and `onEnterBeaconRegion` deliberately does not re-fire (anti-phantom).
+- Example: `BearoundScan` now runs on **API 23+** (bench floor: Galaxy S7 / Android 6) — `minSdk` 26 → 23, guarded `NotificationChannel`, pre-26 launcher icon fallback. Honest Bluetooth-off UI with a one-tap enable path; scan panel shows the real continuous listening mode; zone card initialized from `isInBeaconRegion`. The legacy `:app` module is deprecated (see `app/DEPRECATED.md`).
+- `CLAUDE.md` — agent build/bench playbook.
+
 ## [3.5.1] - 2026-07-22
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,81 @@
+# CLAUDE.md
+
+Guidance for Claude Code when working in this repository (BeAround Android SDK).
+
+## Modules
+
+- `:sdk` — the library (minSdk 23). The only code clients ship.
+- `:BearoundScan` — **the canonical example/bench app** (minSdk 23; runs on the whole
+  device matrix, down to Galaxy S7 / Android 6). This is the reference client
+  integration: FGS enabled, reconfigure via stop+start, honest Bluetooth-off UI.
+- `:app` — legacy example. **Deprecated**: it does not use a ForegroundScanConfig and
+  its `updateConfiguration()` does not restart the scan (precision changes silently
+  don't apply). Do not extend it; point everything at `:BearoundScan`.
+
+## Building & installing the example (bench playbook)
+
+```bash
+./gradlew :BearoundScan:assembleDebug          # build
+adb -s <serial> install -r <apk>               # install (see macOS gotcha below)
+```
+
+### macOS gotcha — "Operation not permitted" on repo files
+If the local checkout was touched by Android Studio, macOS App Management may attach
+`com.apple.macl` to files — shell/adb/Read then fail with EPERM (intermittent,
+per-file). Workarounds, in order:
+1. Grant the Claude Code app **Full Disk Access** (definitive).
+2. **Clone to /tmp and build there** (`git clone <repo> /tmp/bas-clean`); write
+   `local.properties` with `sdk.dir=$HOME/Library/Android/sdk`.
+3. If only the APK is unreadable: copy it via a Gradle `Copy` task (the daemon owns the
+   file), or pull the already-installed APK from another bench device
+   (`adb shell pm path <pkg>` → `adb pull` → install).
+
+### Permissions per Android version (fresh installs)
+- Android 12+: `pm grant <pkg> android.permission.BLUETOOTH_SCAN` (+ `POST_NOTIFICATIONS`,
+  `ACCESS_FINE_LOCATION` recommended)
+- Android ≤11: `ACCESS_FINE_LOCATION` / `ACCESS_COARSE_LOCATION` (legacy gate)
+
+### Bench automation that works
+- **Tap by text** (Compose exposes little): `uiautomator dump` → grep `text="..."` for
+  bounds → `input tap`. In zsh use `set -- ${=var}` for word-splitting.
+- **Unfiltered scans (the BeadSniff sniffer) need the screen ON**:
+  `svc power stayon usb; input keyevent KEYCODE_WAKEUP` — Android suspends unfiltered
+  scans with the screen off.
+- Sniffer app: `io.bearound.beadscan` (tag `BeadSniff`) — logs every raw frame as
+  FUNDIDO / IBEACON_PURO / BEAD_PURO with minor/fw/rssi. The ground truth for "what is
+  actually on the air".
+- **Zombie scan clients** (registered, zero deliveries, `Filter 0 results` in
+  `dumpsys bluetooth_manager`): `cmd bluetooth_manager disable` → `enable` clears the
+  stack; the SDK re-arms itself via its BT state receiver.
+- Boot marker of SDK ≥3.5.1: `Scan refresh timer armed (every 20 min)` in logcat.
+
+### Device matrix quirks (bench)
+- **Galaxy S7 (API 23)**: floor device. Legacy `pidof` lists every process — validate by
+  logcat marker + crash buffer instead.
+- **Moto G35 (Unisoc T760)**: **weak BLE receiver by hardware** — captures ~4-8% of
+  frames the Galaxy A16 captures at the SAME RSSI (firmware scan duty/sensitivity).
+  Expect larger gaps on it; use HIGH there; a bigger gap on the G35 alone is NOT an SDK
+  regression. It is the bench's "low-end receiver" specimen.
+- realme C61 / Moto G35 (Android 14): `neverForLocation` denylist discards any packet
+  containing the iBeacon signature — only pure-0xBEAD frames (firmware v4+) deliver.
+
+## Testing
+
+```bash
+./gradlew :sdk:testDebugUnitTest :sdk:lintDebug   # both gate the PR CI
+```
+Lint runs with warnings-as-errors on NEW errors: annotate permission-guarded BLE calls
+with `@SuppressLint("MissingPermission")` (established pattern in the scanners).
+
+## Release
+
+Follow `PUBLISH.md` strictly. Highlights: version lives ONLY in `gradle.properties`
+(`SDK_VERSION`); CHANGELOG entry `## [X.Y.Z]` is enforced by CI when the version
+changes; README install-snippet pin is manual; tag from `main` AFTER merge; do NOT use
+the `gradle-publish.yml` dispatch (parallel flow, double release). The release job's
+JitPack trigger is a silent no-op — force the build with a GET on the artifact:
+`https://jitpack.io/com/github/Bearound/bearound-android-sdk/vX.Y.Z/bearound-android-sdk-vX.Y.Z.pom`.
+
+## Language
+
+Bench/docs pt-BR; code and commits in English.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # 🐻 BeAround Android SDK
 
+> **Example apps:** o app de referência para integração é o **`:BearoundScan`** (roda em API 23+). O módulo `:app` é legado/deprecado — ver `app/DEPRECATED.md`.
+
 [![JitPack](https://jitpack.io/v/Bearound/bearound-android-sdk.svg)](https://jitpack.io/#Bearound/bearound-android-sdk)
 [![API](https://img.shields.io/badge/API-23%2B-brightgreen.svg?style=flat)](https://android-arsenal.com/api?level=23)
 [![License](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
@@ -133,14 +135,14 @@ allprojects {
 ```kotlin
 // build.gradle.kts
 dependencies {
-    implementation("com.github.Bearound:bearound-android-sdk:v3.5.1")
+    implementation("com.github.Bearound:bearound-android-sdk:v3.5.2")
 }
 ```
 
 ```gradle
 // build.gradle
 dependencies {
-    implementation 'com.github.Bearound:bearound-android-sdk:v3.5.1'
+    implementation 'com.github.Bearound:bearound-android-sdk:v3.5.2'
 }
 ```
 

--- a/app/DEPRECATED.md
+++ b/app/DEPRECATED.md
@@ -1,0 +1,12 @@
+# ⚠️ Módulo deprecado
+
+Este módulo (`:app` / `io.bearound.scan`) é o example **legado** e não deve receber
+evolução. O example canônico — e a referência de integração de cliente — é o
+**`:BearoundScan`** (`io.bearound.bearoundscan`):
+
+- usa `ForegroundScanConfig` (foreground service, a integração recomendada);
+- reconfigura via stop+start (aqui, `updateConfiguration()` **não** reinicia o scan —
+  mudanças de precision silenciosamente não valem);
+- UI honesta de Bluetooth desligado e de estado de zona.
+
+Mantido apenas como referência histórica.

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,4 +10,4 @@ org.gradle.configureondemand=true
 # SDK Metadata
 SDK_GROUP_ID=com.github.Bearound
 SDK_ARTIFACT_ID=bearound-android-sdk
-SDK_VERSION=3.5.1
+SDK_VERSION=3.5.2

--- a/sdk/src/main/java/io/bearound/sdk/BeAroundSDK.kt
+++ b/sdk/src/main/java/io/bearound/sdk/BeAroundSDK.kt
@@ -1017,11 +1017,19 @@ class BeAroundSDK private constructor() {
         // the list stays honest without flickering. LOW gets extra margin for its ~10%
         // duty. (The old formula covered the manual scan+pause duty cycle, which no
         // longer exists.)
-        val beaconTimeout = when (config.scanPrecision) {
+        val baseTimeout = when (config.scanPrecision) {
             ScanPrecision.HIGH, ScanPrecision.MEDIUM -> 15_000L
             ScanPrecision.LOW -> 25_000L
         }
-        beaconManager.setBeaconTimeout(beaconTimeout)
+        // Weak-receiver compensation (Unisoc/Spreadtrum class): the controller captures
+        // a fraction of the air, so useful frames arrive 10-45 s apart even at 25 cm —
+        // double the retention windows so the host list holds steady instead of
+        // flickering (bench: Moto G35 T760, realme C61 T612).
+        val weakRx = io.bearound.sdk.utilities.WeakReceiverProfile.isWeakReceiver
+        val beaconTimeout = if (weakRx) baseTimeout * 2 else baseTimeout
+        val staleMs = if (weakRx) 20_000L else 10_000L
+        if (weakRx) Log.i(TAG, "Weak-receiver SoC detected (${android.os.Build.HARDWARE}) — retention windows doubled")
+        beaconManager.setBeaconTimeout(beaconTimeout, staleMs)
         // Listener emissions of collectedBeacons expire on the same clock as the manager
         // (setBeaconTimeout clamps to its 30s floor — mirror that so the two lists agree).
         listenerBeaconTtlMs = maxOf(beaconTimeout, 30_000L)

--- a/sdk/src/main/java/io/bearound/sdk/BeAroundSDK.kt
+++ b/sdk/src/main/java/io/bearound/sdk/BeAroundSDK.kt
@@ -1000,8 +1000,16 @@ class BeAroundSDK private constructor() {
 
         stopSyncTimer()
 
-        // Adaptive beacon timeout: cover scan + pause + 5s buffer so beacons don't expire mid-duty-cycle
-        val beaconTimeout = config.precisionScanDuration + config.precisionPauseDuration + 5_000L
+        // Beacon eviction timeout for the CONTINUOUS scan modes (3.5.2): a present beacon
+        // delivers every ~1-2 s in foreground (LOW_LATENCY) and every ~5 s window in
+        // background (BALANCED/LOW_POWER), so 15 s ≈ 3+ missed windows before eviction —
+        // the list stays honest without flickering. LOW gets extra margin for its ~10%
+        // duty. (The old formula covered the manual scan+pause duty cycle, which no
+        // longer exists.)
+        val beaconTimeout = when (config.scanPrecision) {
+            ScanPrecision.HIGH, ScanPrecision.MEDIUM -> 15_000L
+            ScanPrecision.LOW -> 25_000L
+        }
         beaconManager.setBeaconTimeout(beaconTimeout)
         // Listener emissions of collectedBeacons expire on the same clock as the manager
         // (setBeaconTimeout clamps to its 30s floor — mirror that so the two lists agree).

--- a/sdk/src/main/java/io/bearound/sdk/BeAroundSDK.kt
+++ b/sdk/src/main/java/io/bearound/sdk/BeAroundSDK.kt
@@ -3,6 +3,7 @@ package io.bearound.sdk
 import android.Manifest
 import android.annotation.SuppressLint
 import android.bluetooth.le.ScanResult
+import android.bluetooth.le.ScanSettings
 import android.content.Context
 import android.content.pm.PackageManager
 import android.location.LocationManager
@@ -146,7 +147,6 @@ class BeAroundSDK private constructor() {
     }
 
     private var syncRunnable: Runnable? = null
-    private var dutyCycleRunnable: Runnable? = null
     private var scanRefreshRunnable: Runnable? = null
 
     private var isSyncing = false
@@ -1010,7 +1010,7 @@ class BeAroundSDK private constructor() {
 
         when (config.scanPrecision) {
             ScanPrecision.HIGH -> startHighPrecision(config)
-            ScanPrecision.MEDIUM, ScanPrecision.LOW -> startDutyCycle(config)
+            ScanPrecision.MEDIUM, ScanPrecision.LOW -> startContinuousLowDuty(config)
         }
     }
 
@@ -1020,6 +1020,7 @@ class BeAroundSDK private constructor() {
     private fun startHighPrecision(config: SDKConfiguration) {
         Log.d(TAG, "HIGH precision: continuous scan, sync every ${config.syncInterval / 1000}s")
 
+        beaconManager.rangingScanMode = null
         beaconManager.startRanging()
 
         syncRunnable = object : Runnable {
@@ -1032,69 +1033,44 @@ class BeAroundSDK private constructor() {
     }
 
     /**
-     * MEDIUM/LOW precision: duty cycle with scan+pause windows
-     * MEDIUM: 3 cycles of 10s scan + 10s pause per 60s window
-     * LOW: 1 cycle of 10s scan + 50s pause per 60s window
+     * MEDIUM/LOW: ONE continuous scan registration with a hardware-managed duty cycle.
+     *
+     * MEDIUM → SCAN_MODE_BALANCED (controller listens ~1 s every ~5 s, ~20% duty);
+     * LOW → SCAN_MODE_LOW_POWER (~0.5 s every ~5 s, ~10% duty). Detections land every
+     * few seconds in both modes; sync stays on the 60 s timer.
+     *
+     * Replaces the manual 10 s-scan/10 s-pause duty cycle: that design consumed 3-4 of
+     * the 5 scan-starts/30 s the OS allows BY DESIGN, so any extra start (watchdog,
+     * batch revive, anti-downgrade refresh, fg/bg flip) tripped the quota and the OS
+     * silently starved every scanner for 30 s+ — field-observed on Moto G35 as
+     * "minutes without a beacon". One registration = zero start churn: the whole
+     * budget stays available for the recovery paths, and beacons never expire inside
+     * an artificial pause window.
      */
-    private fun startDutyCycle(config: SDKConfiguration) {
-        val scanDuration = config.precisionScanDuration
-        val pauseDuration = config.precisionPauseDuration
-        val cycleCount = config.precisionCycleCount
-        val cycleInterval = config.precisionCycleInterval
-
-        Log.d(TAG, "${config.scanPrecision} precision: ${cycleCount}x (${scanDuration/1000}s scan + ${pauseDuration/1000}s pause) per ${cycleInterval/1000}s window")
-
-        runDutyCycleWindow(scanDuration, pauseDuration, cycleCount, cycleInterval)
-    }
-
-    private fun runDutyCycleWindow(
-        scanDuration: Long,
-        pauseDuration: Long,
-        cycleCount: Int,
-        cycleInterval: Long
-    ) {
-        var currentCycle = 0
-
-        fun scheduleCycle() {
-            if (currentCycle >= cycleCount) {
-                // All cycles in this window done — sync and schedule next window
-                Log.d(TAG, "Duty cycle window complete — syncing and scheduling next window")
-                syncBeacons()
-
-                // Calculate remaining time until next window
-                val elapsedInWindow = cycleCount.toLong() * (scanDuration + pauseDuration)
-                val remainingDelay = maxOf(0L, cycleInterval - elapsedInWindow)
-
-                dutyCycleRunnable = Runnable {
-                    runDutyCycleWindow(scanDuration, pauseDuration, cycleCount, cycleInterval)
-                }
-                handler.postDelayed(dutyCycleRunnable!!, remainingDelay)
-                return
-            }
-
-            // Start scan phase
-            Log.d(TAG, "Duty cycle ${currentCycle + 1}/$cycleCount: starting scan (${scanDuration / 1000}s)")
-            beaconManager.resumeRanging()
-            bluetoothManager.resumeScanning()
-
-            // Schedule pause after scan duration
-            dutyCycleRunnable = Runnable {
-                Log.d(TAG, "Duty cycle ${currentCycle + 1}/$cycleCount: pausing (${pauseDuration / 1000}s)")
-                beaconManager.pauseRanging()
-                bluetoothManager.pauseScanning()
-                currentCycle++
-
-                // Schedule next cycle after pause
-                dutyCycleRunnable = Runnable {
-                    scheduleCycle()
-                }
-                handler.postDelayed(dutyCycleRunnable!!, pauseDuration)
-            }
-            handler.postDelayed(dutyCycleRunnable!!, scanDuration)
+    private fun startContinuousLowDuty(config: SDKConfiguration) {
+        val lowPower = config.scanPrecision == ScanPrecision.LOW
+        beaconManager.rangingScanMode = if (lowPower) {
+            ScanSettings.SCAN_MODE_LOW_POWER
+        } else {
+            ScanSettings.SCAN_MODE_BALANCED
         }
 
-        // Start first cycle immediately
-        scheduleCycle()
+        Log.d(
+            TAG,
+            "${config.scanPrecision} precision: continuous " +
+                (if (lowPower) "LOW_POWER (~10% hardware duty)" else "BALANCED (~20% hardware duty)") +
+                " scan, sync every ${config.syncInterval / 1000}s"
+        )
+
+        beaconManager.startRanging()
+
+        syncRunnable = object : Runnable {
+            override fun run() {
+                syncBeacons()
+                handler.postDelayed(this, config.syncInterval)
+            }
+        }
+        handler.postDelayed(syncRunnable!!, config.syncInterval)
     }
 
     private fun restartSyncTimer() {
@@ -1106,8 +1082,6 @@ class BeAroundSDK private constructor() {
     private fun stopSyncTimer() {
         syncRunnable?.let { handler.removeCallbacks(it) }
         syncRunnable = null
-        dutyCycleRunnable?.let { handler.removeCallbacks(it) }
-        dutyCycleRunnable = null
     }
 
     /**

--- a/sdk/src/main/java/io/bearound/sdk/BeAroundSDK.kt
+++ b/sdk/src/main/java/io/bearound/sdk/BeAroundSDK.kt
@@ -162,6 +162,17 @@ class BeAroundSDK private constructor() {
     val isScanning: Boolean
         get() = ::beaconManager.isInitialized && beaconManager.isScanning
 
+    /**
+     * True while the SDK considers the device inside a beacon zone — either the rising
+     * edge fired or a fresh persisted zone was restored across a reconfigure/restart.
+     * Hosts should read this to INITIALIZE their zone UI: the restore path deliberately
+     * does not re-fire [BeAroundSDKListener.onEnterBeaconRegion] (anti-phantom), so a UI
+     * that only listens to enter/exit events shows "outside" after a settings apply even
+     * though detection is active.
+     */
+    val isInBeaconRegion: Boolean
+        get() = ::beaconManager.isInitialized && beaconManager.isInBeaconRegion
+
     val currentSyncInterval: Long?
         get() = configuration?.syncInterval
 

--- a/sdk/src/main/java/io/bearound/sdk/BeaconManager.kt
+++ b/sdk/src/main/java/io/bearound/sdk/BeaconManager.kt
@@ -27,10 +27,14 @@ import kotlin.math.pow
 class BeaconManager(private val context: Context) {
     companion object {
         private const val TAG = "BeAroundSDK-BeaconM"
-        // Grace period before a beacon is considered "gone". Long enough to
-        // absorb BLE radio dropouts while the device is stationary inside the
-        // zone — short values caused enter/exit flicker (5s → 30s).
-        private const val BEACON_TIMEOUT_DEFAULT = 30000L
+        // Default/floor for the beacon eviction timeout. Region enter/exit flicker is
+        // no longer a concern here — the zone falling edge has its own 5-min grace
+        // (ZONE_EXIT_GRACE_MS), so this only controls how fast the host LIST drops a
+        // vanished beacon. With the continuous scan modes (3.5.2) a present beacon
+        // delivers every ~1-5 s, so the SDK sets 15-25 s per precision; 10 s is the
+        // hard floor for callers of setBeaconTimeout.
+        private const val BEACON_TIMEOUT_DEFAULT = 15000L
+        private const val BEACON_TIMEOUT_FLOOR = 10000L
         private const val WATCHDOG_INTERVAL = 30000L
         private const val RANGING_REFRESH_INTERVAL = 120000L
         private const val MAX_RESTARTS_PER_MINUTE = 3
@@ -247,7 +251,7 @@ class BeaconManager(private val context: Context) {
      * scan precision (scan + pause + buffer).
      */
     fun setBeaconTimeout(timeoutMs: Long) {
-        beaconTimeoutMs = timeoutMs.coerceAtLeast(BEACON_TIMEOUT_DEFAULT)
+        beaconTimeoutMs = timeoutMs.coerceAtLeast(BEACON_TIMEOUT_FLOOR)
     }
 
     private val scanCallback = object : ScanCallback() {

--- a/sdk/src/main/java/io/bearound/sdk/BeaconManager.kt
+++ b/sdk/src/main/java/io/bearound/sdk/BeaconManager.kt
@@ -109,6 +109,19 @@ class BeaconManager(private val context: Context) {
     var isInBeaconRegion: Boolean = false
         private set
 
+    /**
+     * Scan mode for the ranging client, set by the SDK from the active precision.
+     * MEDIUM → BALANCED (~20% hardware duty, listen window every ~5 s);
+     * LOW → LOW_POWER (~10%, every ~5 s); null (HIGH) → legacy behavior
+     * (LOW_LATENCY in foreground, BALANCED in background). Continuous registration:
+     * the controller manages the duty in hardware, so the client is registered ONCE —
+     * unlike the old manual start/stop duty cycle, which spent 3-4 of the 5
+     * scan-starts/30 s the OS allows and starved every scanner when anything else
+     * (watchdog, batch revive, refresh) needed a start (field: Moto G35).
+     */
+    @Volatile
+    var rangingScanMode: Int? = null
+
     // Callbacks
     var onBeaconsUpdated: ((List<Beacon>) -> Unit)? = null
     var onError: ((Exception) -> Unit)? = null
@@ -448,9 +461,11 @@ class BeaconManager(private val context: Context) {
                 .build()
         )
 
-        // Foreground service is active -> BALANCED (not LOW_POWER) for faster detection; Android throttles anyway without a FG service.
-        val scanMode = if (isInForeground) ScanSettings.SCAN_MODE_LOW_LATENCY
-                       else ScanSettings.SCAN_MODE_BALANCED
+        // Precision override first (MEDIUM/LOW continuous hardware duty); HIGH falls back
+        // to the legacy rule: LOW_LATENCY in foreground, BALANCED in background.
+        val scanMode = rangingScanMode
+            ?: if (isInForeground) ScanSettings.SCAN_MODE_LOW_LATENCY
+               else ScanSettings.SCAN_MODE_BALANCED
 
         val settings = ScanSettings.Builder()
             .setScanMode(scanMode)

--- a/sdk/src/main/java/io/bearound/sdk/BeaconManager.kt
+++ b/sdk/src/main/java/io/bearound/sdk/BeaconManager.kt
@@ -171,6 +171,7 @@ class BeaconManager(private val context: Context) {
      * scan + pause + buffer for the active precision mode (5s HIGH, 25s MEDIUM, 65s LOW).
      */
     private var beaconTimeoutMs: Long = BEACON_TIMEOUT_DEFAULT
+    private var staleThresholdMs: Long = STALE_THRESHOLD_MS
     
     private var lastBeaconUpdate: Long? = null
     private var emptyBeaconCount = 0
@@ -257,8 +258,9 @@ class BeaconManager(private val context: Context) {
      * Should be set to cover the worst-case gap between packets for the active
      * scan precision (scan + pause + buffer).
      */
-    fun setBeaconTimeout(timeoutMs: Long) {
+    fun setBeaconTimeout(timeoutMs: Long, staleMs: Long = STALE_THRESHOLD_MS) {
         beaconTimeoutMs = timeoutMs.coerceAtLeast(BEACON_TIMEOUT_FLOOR)
+        staleThresholdMs = staleMs.coerceAtLeast(5_000L)
     }
 
     private val scanCallback = object : ScanCallback() {
@@ -770,7 +772,7 @@ class BeaconManager(private val context: Context) {
             for (id in detectedBeacons.keys.toList()) {
                 val b = detectedBeacons[id] ?: continue
                 val lastSeen = beaconLastSeen[id] ?: now
-                val staleNow = (now - lastSeen) > STALE_THRESHOLD_MS
+                val staleNow = (now - lastSeen) > staleThresholdMs
                 if (staleNow != b.isStale) {
                     detectedBeacons[id] = b.copy(isStale = staleNow)
                     changed = true

--- a/sdk/src/main/java/io/bearound/sdk/BeaconManager.kt
+++ b/sdk/src/main/java/io/bearound/sdk/BeaconManager.kt
@@ -310,6 +310,7 @@ class BeaconManager(private val context: Context) {
     }
 
     fun setForegroundState(inForeground: Boolean) {
+        val changed = isInForeground != inForeground
         isInForeground = inForeground
 
         if (!inForeground && isScanning) {
@@ -317,6 +318,28 @@ class BeaconManager(private val context: Context) {
         } else if (inForeground) {
             stopRangingRefreshTimer()
         }
+
+        // The effective scan mode depends on the app state (foreground → LOW_LATENCY,
+        // background → precision mode), so a fg/bg flip must re-register the ranging
+        // client with the new mode. Budget-aware via restartRanging(): when there is no
+        // start headroom the current session is kept — never killed without a replacement.
+        if (changed && isScanning && isRanging) {
+            restartRangingForModeChange()
+        }
+    }
+
+    /** Stop+start the ranging client so the scan mode matches the current app state. */
+    @SuppressLint("MissingPermission")
+    private fun restartRangingForModeChange() {
+        if (!ScanStartBudget.tryAcquire("ranging-mode-flip")) return
+        try {
+            bluetoothLeScanner?.stopScan(scanCallback)
+        } catch (_: Exception) {
+            /* session already gone in the stack — the start below recreates it */
+        }
+        isRanging = false
+        startRanging()
+        Log.d(TAG, "Ranging re-registered for app-state change (foreground=$isInForeground)")
     }
 
     /**
@@ -461,11 +484,17 @@ class BeaconManager(private val context: Context) {
                 .build()
         )
 
-        // Precision override first (MEDIUM/LOW continuous hardware duty); HIGH falls back
-        // to the legacy rule: LOW_LATENCY in foreground, BALANCED in background.
-        val scanMode = rangingScanMode
-            ?: if (isInForeground) ScanSettings.SCAN_MODE_LOW_LATENCY
-               else ScanSettings.SCAN_MODE_BALANCED
+        // Adaptive: in FOREGROUND every precision gets LOW_LATENCY — the user is looking
+        // at the screen, detection must feel fluid, and the display dwarfs the radio cost.
+        // In BACKGROUND each precision pays its own price: HIGH/MEDIUM → BALANCED (~20%
+        // hardware duty), LOW → LOW_POWER (~10%) — see [rangingScanMode]. This is what
+        // makes MEDIUM a safe default: integrators get best-in-class foreground detection
+        // automatically and a battery-honest background without configuring anything.
+        val scanMode = if (isInForeground) {
+            ScanSettings.SCAN_MODE_LOW_LATENCY
+        } else {
+            rangingScanMode ?: ScanSettings.SCAN_MODE_BALANCED
+        }
 
         val settings = ScanSettings.Builder()
             .setScanMode(scanMode)

--- a/sdk/src/main/java/io/bearound/sdk/BeaconManager.kt
+++ b/sdk/src/main/java/io/bearound/sdk/BeaconManager.kt
@@ -58,8 +58,15 @@ class BeaconManager(private val context: Context) {
          * at most once per window keeps the revive itself far below the quota (5/30 s).
          */
         private const val BATCH_LIVENESS_TIMEOUT_MS = 120_000L
-        /** Past this gap with no packet, the beacon is rendered as stale (faded) but kept. */
-        private const val STALE_THRESHOLD_MS = 5000L
+        /**
+         * Past this gap with no packet, the beacon is rendered as stale (faded) but kept.
+         * 10 s (was 5 s): with sparse receivers (weak-RX devices, background windows)
+         * packets legally arrive every 3-8 s, and a 5 s threshold made rows blink
+         * opaque↔faded constantly. At 10 s the fade only shows as a short "leaving"
+         * warning right before the 15 s eviction — a detected beacon holds SOLID on
+         * screen through normal delivery gaps, and every new packet resets the clock.
+         */
+        private const val STALE_THRESHOLD_MS = 10_000L
         /**
          * How long the BLE eye waits without ANY beacon detection before firing
          * [onRegionExit]. Decoupled from [beaconTimeout] (which controls per-beacon

--- a/sdk/src/main/java/io/bearound/sdk/BluetoothManager.kt
+++ b/sdk/src/main/java/io/bearound/sdk/BluetoothManager.kt
@@ -28,6 +28,8 @@ class BluetoothManager(private val context: Context) {
     }
 
     var listener: BluetoothManagerListener? = null
+
+    private val handler = android.os.Handler(android.os.Looper.getMainLooper())
     
     private var bluetoothAdapter: BluetoothAdapter? = null
     private var bluetoothLeScanner: BluetoothLeScanner? = null
@@ -67,6 +69,21 @@ class BluetoothManager(private val context: Context) {
             Log.e(TAG, "BLE scan failed with error code: $errorCode")
             if (errorCode == 6 /* SCAN_FAILED_SCANNING_TOO_FREQUENTLY, API 30+ */) {
                 ScanStartBudget.freeze()
+            }
+            if (errorCode == 1 /* SCAN_FAILED_ALREADY_STARTED */) {
+                // Stack/SDK state desync: the controller thinks this callback is still
+                // registered (failed stop, BT cycle) while isScanning here says otherwise.
+                // Without healing, the metadata scan stays a zombie until a full app
+                // restart (field: Moto G35, code-1 loop). Clear the stale registration and
+                // re-arm once — startScanning() re-checks the ScanStartBudget, which also
+                // acts as the natural brake against a heal loop.
+                try {
+                    bluetoothLeScanner?.stopScan(this)
+                } catch (_: Exception) {
+                    /* stale registration — nothing to stop */
+                }
+                isScanning = false
+                handler.postDelayed({ startScanning() }, 500L)
             }
         }
     }

--- a/sdk/src/main/java/io/bearound/sdk/BluetoothManager.kt
+++ b/sdk/src/main/java/io/bearound/sdk/BluetoothManager.kt
@@ -71,21 +71,28 @@ class BluetoothManager(private val context: Context) {
                 ScanStartBudget.freeze()
             }
             if (errorCode == 1 /* SCAN_FAILED_ALREADY_STARTED */) {
-                // Stack/SDK state desync: the controller thinks this callback is still
-                // registered (failed stop, BT cycle) while isScanning here says otherwise.
-                // Without healing, the metadata scan stays a zombie until a full app
-                // restart (field: Moto G35, code-1 loop). Clear the stale registration and
-                // re-arm once — startScanning() re-checks the ScanStartBudget, which also
-                // acts as the natural brake against a heal loop.
-                try {
-                    bluetoothLeScanner?.stopScan(this)
-                } catch (_: Exception) {
-                    /* stale registration — nothing to stop */
-                }
-                isScanning = false
-                handler.postDelayed({ startScanning() }, 500L)
+                healZombieScanRegistration()
             }
         }
+    }
+
+    /**
+     * Self-heal for SCAN_FAILED_ALREADY_STARTED: stack/SDK state desync (failed stop,
+     * BT cycle) leaves the controller thinking this callback is still registered while
+     * [isScanning] says otherwise — the metadata scan stays a zombie until a full app
+     * restart (field: Moto G35, code-1 loop). Clear the stale registration and re-arm
+     * once; startScanning() re-checks the ScanStartBudget, which is also the natural
+     * brake against a heal loop.
+     */
+    @SuppressLint("MissingPermission")
+    private fun healZombieScanRegistration() {
+        try {
+            bluetoothLeScanner?.stopScan(scanCallback)
+        } catch (_: Exception) {
+            /* stale registration — nothing to stop */
+        }
+        isScanning = false
+        handler.postDelayed({ startScanning() }, 500L)
     }
 
     /**

--- a/sdk/src/main/java/io/bearound/sdk/utilities/ScanStartBudget.kt
+++ b/sdk/src/main/java/io/bearound/sdk/utilities/ScanStartBudget.kt
@@ -7,7 +7,11 @@ import java.util.ArrayDeque
  * Preventive guard for the OS BLE scan-start quota (5 starts per 30 s per app — exceeding it
  * leaves the scan client registered but permanently SILENT, with no error on most versions).
  *
- * The SDK's duty cycle alone runs at 4 starts/30 s in MEDIUM precision; its own side events
+ * Since 3.5.2 the manual duty cycle is gone (MEDIUM/LOW register ONE continuous scan with
+ * hardware-managed duty), so the budget's former biggest consumer no longer exists — the
+ * full window now belongs to the recovery paths (watchdog restarts, batch revive,
+ * anti-downgrade refresh, fg/bg mode flips). Historically the duty cycle alone ran at
+ * 4 starts/30 s and its side events
  * (watchdog restarts, batch revive, foreground↔background flips, region enter) consume the
  * remaining headroom and silently starve scanners in perfectly normal usage. Every internal
  * `startScan` call must pass through [tryAcquire]; callers that get `false` should SKIP this

--- a/sdk/src/main/java/io/bearound/sdk/utilities/WeakReceiverProfile.kt
+++ b/sdk/src/main/java/io/bearound/sdk/utilities/WeakReceiverProfile.kt
@@ -1,0 +1,34 @@
+package io.bearound.sdk.utilities
+
+import android.os.Build
+
+/**
+ * Detects chipsets with a weak BLE *receiver* — SoCs whose controller firmware opens
+ * tiny listen windows regardless of the requested scan mode.
+ *
+ * Bench-measured (2026-07): Unisoc/Spreadtrum devices (Moto G35 / T760, realme C61 /
+ * T612) capture ~2-8% of the frames a mid-range Exynos (Galaxy A16) captures at the
+ * SAME RSSI, screen on, LOW_LATENCY granted, host reporting continuous scan time.
+ * No software setting recovers the missing frames — but the SDK can compensate on the
+ * RETENTION side: with sparse captures, gaps between useful frames stretch to 10-45 s,
+ * so eviction/stale windows are doubled on these devices to keep the host list stable
+ * ("detected → holds on screen") instead of flickering.
+ *
+ * Detection is signature-based and conservative: [Build.SOC_MANUFACTURER] (API 31+,
+ * "Unisoc"/"Spreadtrum") with a [Build.HARDWARE] prefix fallback ("ums*"/"sprd*"/"sp98*")
+ * for older API levels. False negatives just keep default timings; false positives only
+ * make a list slightly more patient.
+ */
+internal object WeakReceiverProfile {
+
+    val isWeakReceiver: Boolean by lazy { detect() }
+
+    private fun detect(): Boolean {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            val soc = Build.SOC_MANUFACTURER.lowercase()
+            if (soc.contains("unisoc") || soc.contains("spreadtrum")) return true
+        }
+        val hw = Build.HARDWARE.lowercase()
+        return hw.startsWith("ums") || hw.startsWith("sprd") || hw.startsWith("sp98")
+    }
+}


### PR DESCRIPTION
## O que este PR entrega (pacote "detecção fluida")

### 1️⃣ MEDIUM/LOW → registro ÚNICO com duty de HARDWARE
| Precision | Antes (manual) | Agora |
|---|---|---|
| MEDIUM | 3× (10 s scan + 10 s pausa)/60 s | `BALANCED` contínuo (~20% duty, janela ~5 s), **1 registro** |
| LOW | 1× (10 s + 50 s)/60 s | `LOW_POWER` contínuo (~10%), **1 registro** |

O duty manual gastava **3-4 dos 5 scan-starts/30 s permitidos pelo OS, por design** — qualquer start extra (watchdog, revive, refresh, flip fg/bg) estourava o quota e o Android silenciava TODOS os scanners por 30 s+ (campo: Moto G35, "minutos sem beacon" com o duty visivelmente rodando e `Filter 0 results`). Um registro = zero churn; o budget inteiro fica para os caminhos de recuperação.

### 2️⃣ Adaptive foreground boost — o melhor automaticamente, zero config
**Foreground = `LOW_LATENCY` em QUALQUER precision** (o usuário está olhando; a tela domina o custo). Background = o modo econômico de cada precision. O flip fg↔bg re-registra o ranging com o modo novo (budget-aware). **É o que torna o MEDIUM um default plug & play**: integradores recebem a melhor detecção em uso e um background honesto de bateria sem configurar nada.

### 3️⃣ Self-heal do `SCAN_FAILED_ALREADY_STARTED` (code 1)
Dessincronia stack×SDK deixava o metadata scan zumbi até reiniciar o app (campo: G35). Limpa o registro velho e re-arma uma vez; `ScanStartBudget` é o freio anti-loop.

### 4️⃣ Follow-ups de coerência
- **Timeout de expiração** agora reflete o contínuo: 15 s (HIGH/MEDIUM) / 25 s (LOW) — lista viva sem flicker (fórmula antiga descrevia o duty morto e clampava tudo em 30 s)
- Painel do example: "Duração/Pausa" (sem sentido no contínuo) → linha **"Escuta"** honesta
- Doc do `ScanStartBudget` atualizada
- **CLAUDE.md** novo: playbook de build/bancada (macOS App Management, ponte de APK, automação, quirks da matriz — S7 piso, G35 receptor fraco por hardware, denylist A14)

## Validação em campo (Galaxy A16, beacon v5)
- `MEDIUM precision: continuous BALANCED (~20% hardware duty)` + **zero** logs de duty manual + sync 60 s cravado ✅
- `Ranging re-registered for app-state change (foreground=false)` no HOME ✅
- `Beacon timeout set to 15000ms` + linha "Escuta: Máxima em uso; ~20% em 2º plano" ✅
- A/B no G35 (receptor fraco): MEDIUM 20% = 0 entregas com sinal no limite; HIGH contínuo = detecta e sinca — o adaptive dá esse comportamento automaticamente em foreground ✅
- Lint + testes unitários verdes ✅

## Compatibilidade
Sem mudança de API pública. `pauseRanging`/`resumeRanging`/etc. permanecem (sem uso no fluxo novo).