### PR TITLE
feat(scan): aggressive controller matching on every scanner

### DIFF
--- a/sdk/src/main/java/io/bearound/sdk/BeaconManager.kt
+++ b/sdk/src/main/java/io/bearound/sdk/BeaconManager.kt
@@ -510,6 +510,10 @@ class BeaconManager(private val context: Context) {
         }
 
         val settings = ScanSettings.Builder()
+            // Aggressive controller matching: max sensitivity + every advertisement
+            // reported — conservative OEM hardware filters drop fewer frames this way.
+            .setMatchMode(ScanSettings.MATCH_MODE_AGGRESSIVE)
+            .setNumOfMatches(ScanSettings.MATCH_NUM_MAX_ADVERTISEMENT)
             .setScanMode(scanMode)
             .setReportDelay(0)
             .build()
@@ -625,6 +629,10 @@ class BeaconManager(private val context: Context) {
                 .setServiceData(IBeaconParser.BEAD_SERVICE_UUID, byteArrayOf(), byteArrayOf())
                 .build()
             val settings = ScanSettings.Builder()
+                // Aggressive controller matching: max sensitivity + every advertisement
+                // reported — conservative OEM hardware filters drop fewer frames this way.
+                .setMatchMode(ScanSettings.MATCH_MODE_AGGRESSIVE)
+                .setNumOfMatches(ScanSettings.MATCH_NUM_MAX_ADVERTISEMENT)
                 .setScanMode(ScanSettings.SCAN_MODE_LOW_LATENCY)
                 .setCallbackType(ScanSettings.CALLBACK_TYPE_ALL_MATCHES)
                 .setReportDelay(SLOW_BEACON_BATCH_DELAY_MS)

--- a/sdk/src/main/java/io/bearound/sdk/BluetoothManager.kt
+++ b/sdk/src/main/java/io/bearound/sdk/BluetoothManager.kt
@@ -139,6 +139,10 @@ class BluetoothManager(private val context: Context) {
 
         try {
             val settings = ScanSettings.Builder()
+                // Aggressive controller matching: max sensitivity + every advertisement
+                // reported — conservative OEM hardware filters drop fewer frames this way.
+                .setMatchMode(ScanSettings.MATCH_MODE_AGGRESSIVE)
+                .setNumOfMatches(ScanSettings.MATCH_NUM_MAX_ADVERTISEMENT)
                 // Foreground service is active -> BALANCED (not LOW_POWER) for faster detection; Android throttles anyway without a FG service.
                 .setScanMode(ScanSettings.SCAN_MODE_BALANCED)
                 .setReportDelay(0)
@@ -174,6 +178,10 @@ class BluetoothManager(private val context: Context) {
         }
         try {
             val settings = ScanSettings.Builder()
+                // Aggressive controller matching: max sensitivity + every advertisement
+                // reported — conservative OEM hardware filters drop fewer frames this way.
+                .setMatchMode(ScanSettings.MATCH_MODE_AGGRESSIVE)
+                .setNumOfMatches(ScanSettings.MATCH_NUM_MAX_ADVERTISEMENT)
                 .setScanMode(ScanSettings.SCAN_MODE_BALANCED)
                 .setReportDelay(0)
                 .build()
@@ -227,6 +235,10 @@ class BluetoothManager(private val context: Context) {
         if (!ScanStartBudget.tryAcquire("metadata-resume")) return
         try {
             val settings = ScanSettings.Builder()
+                // Aggressive controller matching: max sensitivity + every advertisement
+                // reported — conservative OEM hardware filters drop fewer frames this way.
+                .setMatchMode(ScanSettings.MATCH_MODE_AGGRESSIVE)
+                .setNumOfMatches(ScanSettings.MATCH_NUM_MAX_ADVERTISEMENT)
                 // Foreground service is active -> BALANCED (not LOW_POWER) for faster detection; Android throttles anyway without a FG service.
                 .setScanMode(ScanSettings.SCAN_MODE_BALANCED)
                 .setReportDelay(0)

--- a/sdk/src/main/java/io/bearound/sdk/background/BackgroundScanManager.kt
+++ b/sdk/src/main/java/io/bearound/sdk/background/BackgroundScanManager.kt
@@ -130,6 +130,10 @@ class BackgroundScanManager(private val context: Context) {
             )
             
             val settings = ScanSettings.Builder()
+                // Aggressive controller matching: max sensitivity + every advertisement
+                // reported — conservative OEM hardware filters drop fewer frames this way.
+                .setMatchMode(ScanSettings.MATCH_MODE_AGGRESSIVE)
+                .setNumOfMatches(ScanSettings.MATCH_NUM_MAX_ADVERTISEMENT)
                 // Foreground service is active -> BALANCED (not LOW_POWER) for faster detection; Android throttles anyway without a FG service.
                 .setScanMode(ScanSettings.SCAN_MODE_BALANCED)
                 .setCallbackType(ScanSettings.CALLBACK_TYPE_ALL_MATCHES)


### PR DESCRIPTION
## Summary

- `MATCH_MODE_AGGRESSIVE` + `MATCH_NUM_MAX_ADVERTISEMENT` on every `ScanSettings` builder (ranging, metadata, slow-beacon batch, background PendingIntent).
- Maximum controller sensitivity and every advertisement reported — conservative OEM hardware filters drop fewer frames, which matters most for weak signals and weak-receiver SoCs (Unisoc class).
- Same change ships in the Bearound Telemetry SDK 0.2.x line, keeping both SDKs' scan behavior aligned.

## Validation

- Unit tests + lint green.
- Field check on realme C61 (weak receiver) running on the telemetry twin of this change — no regression vs. the continuous-scan baseline.