### PR TITLE
feat: persisted detection log with app-state tagging (1:1 with iOS)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Persisted detection log with app-state tagging** — `getDetectionLogJson()` / `clearDetectionLog()`, mirroring the iOS SDK 1:1 (same `type`/`detail` strings, same 500-entry cap, same JSON shape). Entries carry the process state at write time: `foreground`, `background`, `backgroundLocked` or `terminated`, the last one meaning the system started the process with the app closed (broadcast-delivered scan, boot, watchdog). Backed by SharedPreferences, so those entries survive process death and are still there when the user opens the app; `terminated` writes are flushed synchronously because the system may kill the process right after the wake-up callback. This closes a parity gap the iOS source already documented as existing ("Mirrors the Android `DetectionLogStore`") and unblocks host UIs — the Flutter plugin previously answered `getPersistedLog()` with a hardcoded `[]` on Android. See [docs/DETECTION-LOG.md](docs/DETECTION-LOG.md).
+
 ## [3.6.1] - 2026-07-24
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -524,6 +524,32 @@ foreground service.** Consequences on the Play Console:
   android:required="false" />` — it does **not** restrict your app's Play Store availability.
   If your app genuinely requires BLE, override it to `required="true"` in your own manifest.
 
+### Detection log (persisted, with app state)
+
+Logcat cannot answer "did the SDK see anything while the app was closed?" — nobody
+is attached at that moment. The SDK keeps a **persisted** diagnostic log for that,
+tagging every event with the process state at write time:
+
+```kotlin
+val json = sdk.getDetectionLogJson()  // JSON array, newest first, max 500 entries
+sdk.clearDetectionLog()
+```
+
+```json
+{ "id": "…", "timestamp": 1753812345678, "state": "terminated", "type": "Scan", "detail": "0.205 rssi=-61" }
+```
+
+`state` is `foreground`, `background`, `backgroundLocked` or **`terminated`** — the
+last one meaning the process is alive but the UI never became active, i.e. the
+system started the app (broadcast-delivered scan result, boot, watchdog) with the
+app closed. Because it is written to disk, those entries are still there when the
+user finally opens the app.
+
+The entry `type`/`detail` strings are identical to the iOS SDK (`Scan`,
+`Background`, `Região`, `Sync OK`, `Sync falhou`), so one host UI renders both
+platforms with no platform branch. Full contract, implementation notes and field
+validation: [docs/DETECTION-LOG.md](docs/DETECTION-LOG.md).
+
 ### Background reliability
 
 Keeping the process eligible to wake under Doze and aggressive OEM battery managers is the

--- a/docs/DETECTION-LOG.md
+++ b/docs/DETECTION-LOG.md
@@ -1,0 +1,124 @@
+# Detection log (persisted) — Android ↔ iOS parity
+
+The detection log answers one question that logcat cannot: **"what did the SDK
+see, and with the app in which state?"** — including events that happened while
+the app was closed, which is exactly when a host app has nobody watching.
+
+It is a diagnostic surface, not a product feature: no notifications, no user data
+beyond beacon identifiers and RSSI.
+
+## Why it exists on Android
+
+The iOS SDK has had this since the state-restoration work, and its source even
+documents *"Mirrors the Android `DetectionLogStore`"* — but that Android store
+never existed. Consequences we hit in the field:
+
+- The Flutter plugin answered `getPersistedLog()` with a hardcoded `"[]"` on
+  Android (an explicit iOS-only stub), so the host's Log screen was **always
+  empty** — indistinguishable from "background collection is broken", which cost
+  a full debugging session.
+- The native `BearoundScan` sample worked around it by building its own in-memory
+  log in the ViewModel, which dies with the process — so `terminated` could never
+  be shown, on any Android host.
+
+This document describes the Android implementation, which is a 1:1 port of the
+iOS contract.
+
+## Contract (identical on both platforms)
+
+Entry shape, newest first, capped at **500** entries:
+
+```json
+{ "id": "…", "timestamp": 1753812345678, "state": "terminated", "type": "Scan", "detail": "0.205 rssi=-61" }
+```
+
+### States
+
+| `state` | Meaning |
+|---|---|
+| `foreground` | An Activity is resumed (iOS: `UIApplication.State.active`) |
+| `background` | The UI ran before, nothing resumed now |
+| `backgroundLocked` | Same as background, device screen locked |
+| `terminated` | **The process is alive but the UI never became active** — the system started us with the app closed |
+
+The `terminated` heuristic is the same on both platforms: *process alive, UI never
+active*. On Android that means a broadcast-delivered scan result, `BOOT_COMPLETED`
+or the watchdog alarm started the process; on iOS, a CoreBluetooth state
+restoration or region-monitoring relaunch.
+
+### Types and details
+
+Verbatim strings, shared by both SDKs so a single host UI renders both:
+
+| `type` | `detail` | When |
+|---|---|---|
+| `Scan` | `0.205 rssi=-61` (comma-joined for several beacons) | Ranging saw beacons — **throttled**: one entry per composition change or every 10 s |
+| `Background` | `N beacon(s) detectado(s)` | Detection while the app is backgrounded |
+| `Região` | `Entrou na zona do beacon` / `Saiu da zona do beacon` | Region transitions |
+| `Sync OK` | `N beacon(s) enviados ao ingester` | Upload succeeded (normal + retry-chunk paths) |
+| `Sync falhou` | `N beacon(s) · <erro>` | Upload failed (normal + retry-chunk paths) |
+
+The throttle matters: without it a HIGH-precision scan writes several entries per
+second and the 500-entry window covers barely a minute.
+
+## Implementation (Android)
+
+| File | Role |
+|---|---|
+| `utilities/AppStateMonitor.kt` | Classifies the process state. Registers `ActivityLifecycleCallbacks` to learn whether any Activity ever resumed (`wasEverActive`), and reads `KeyguardManager`/`PowerManager` for the locked case. |
+| `utilities/DetectionLogStore.kt` | SharedPreferences-backed JSON array (the counterpart of iOS `UserDefaults`), with an in-memory mirror for cheap reads. |
+
+Two details that are not cosmetic:
+
+1. **`terminated` entries are flushed with `commit()`**, everything else with
+   `apply()`. The system may kill the process immediately after the wake-up
+   callback; an async write would lose exactly the evidence this log exists to
+   capture. iOS does the same with `UserDefaults.synchronize()`.
+2. **Diagnostics never break detection**: every store operation is wrapped, and a
+   failure only logs a warning.
+
+## Public API
+
+```kotlin
+BeAroundSDK.getInstance(context).getDetectionLogJson()  // JSON array string
+BeAroundSDK.getInstance(context).clearDetectionLog()
+```
+
+Same names and semantics as iOS (`getDetectionLogJson()` / `clearDetectionLog()`),
+so the Flutter plugin forwards both platforms through one code path — no
+`Platform.isAndroid` branch in host apps.
+
+## Reading it in a host app
+
+The Flutter example's Log screen (`example/lib/log_modal.dart` in
+`bearound-flutter-sdk`) is the reference host UI, mirroring the native iOS
+`DetectionLogView`:
+
+- Counters per state: **FG / BG / BG🔒 / Terminated**
+- View modes: **Detalhado** (raw entries) and **Por Minuto** (aggregation)
+- Per-minute row: `dd/MM HH:mm`, `N detecções`, per-state badges (`FG`/`BG`/`LK`/`T`,
+  shown only when non-zero) and the number of distinct beacons in that minute
+- State filters: Todos / Foreground / Background / BG bloqueado / Terminated
+
+## Field validation (Galaxy A16, Android 16, 2026-07-29)
+
+- **Background**: app backgrounded with the screen off → `FG 8 / BG 33`, with
+  `Background`, `Scan` and `Sync OK` entries tagged `background`.
+- **Terminated**: device rebooted, app never opened → the SDK came up headless via
+  `BOOT_COMPLETED` (no Activity in the logs), detected and synced, and the log
+  showed **5 `terminated` entries** (`Scan · 0.205 rssi=-61`, `Sync OK · 1
+  beacon(s) enviados ao ingester`), which survived the process being started and
+  stopped before the app was opened.
+
+### Known OS limits (not SDK limits)
+
+- **Force stop** (Settings → Force stop) on **Android 15+** leaves the package in
+  the *stopped* state: broadcasts are not delivered and PendingIntents/alarms are
+  cancelled until the user opens the app again. No detections happen, so there is
+  nothing to log. Verified with a clean 5-minute window on the A16 (zero SDK
+  activity, zero taps). Older versions (verified: realme C61, Android 14) do
+  revive after force stop.
+- With the **foreground service** enabled the process is effectively unkillable
+  (`am kill` / `am kill-all` / swipe from Recents all fail to kill it), so
+  `terminated` rarely appears in that configuration — the app simply keeps
+  running in `background`.

--- a/sdk/src/main/java/io/bearound/sdk/BeAroundSDK.kt
+++ b/sdk/src/main/java/io/bearound/sdk/BeAroundSDK.kt
@@ -34,6 +34,8 @@ import io.bearound.sdk.telemetry.ErrorReporter
 import io.bearound.sdk.utilities.BackgroundReliabilityHelper
 import io.bearound.sdk.utilities.OemPowerProfile
 import io.bearound.sdk.utilities.DeviceIdentifier
+import io.bearound.sdk.utilities.AppStateMonitor
+import io.bearound.sdk.utilities.DetectionLogStore
 import io.bearound.sdk.utilities.DeviceInfoCollector
 import io.bearound.sdk.utilities.DiagnosticsStore
 import io.bearound.sdk.utilities.OfflineBatchStorage
@@ -57,6 +59,9 @@ import kotlin.math.pow
 class BeAroundSDK private constructor() {
     companion object {
         private const val TAG = "BeAroundSDK"
+
+        /** Scan-log throttle window — same 10 s the iOS SDK uses. */
+        private const val SCAN_LOG_THROTTLE_MS = 10_000L
 
         /**
          * Anti-downgrade scan refresh (Fix B, 2026-07). OEMs on Android 13+ silently
@@ -168,6 +173,10 @@ class BeAroundSDK private constructor() {
         }
     }
 
+    /** Scan-log throttle state — mirrors iOS `lastScanLogSignature`/`lastScanLogAt`. */
+    private var lastScanLogSignature: String? = null
+    private var lastScanLogAt: Long = 0L
+
     private var syncRunnable: Runnable? = null
     private var scanRefreshRunnable: Runnable? = null
 
@@ -247,6 +256,11 @@ class BeAroundSDK private constructor() {
         
         SecureStorage.initialize(context)
         
+        // Process-state classification for the persisted detection log — must be
+        // installed before anything can record, so events from a system-started
+        // process are tagged `terminated` instead of `background`.
+        AppStateMonitor.install(context)
+
         deviceInfoCollector = DeviceInfoCollector(context, isColdStart)
         beaconManager = BeaconManager(context)
         bluetoothManager = BluetoothManager(context)
@@ -293,8 +307,28 @@ class BeAroundSDK private constructor() {
             // Notify listener of beacon update (with sync state preserved)
             dispatchToListener { it.onBeaconsUpdated(beaconsForListener) }
 
+            // Ranged-scan log (diagnostic, persisted): one entry per composition
+            // change or every 10 s — same contract and format as iOS, so the same
+            // host UI reads both platforms identically.
+            if (enrichedBeacons.isNotEmpty()) {
+                val signature = enrichedBeacons.joinToString(", ") {
+                    "${it.major}.${it.minor} rssi=${it.rssi}"
+                }
+                val now = System.currentTimeMillis()
+                if (signature != lastScanLogSignature || now - lastScanLogAt > SCAN_LOG_THROTTLE_MS) {
+                    lastScanLogSignature = signature
+                    lastScanLogAt = now
+                    DetectionLogStore.append(context, type = "Scan", detail = signature)
+                }
+            }
+
             // Notify if beacons detected in background
             if (isInBackground && enrichedBeacons.isNotEmpty()) {
+                DetectionLogStore.append(
+                    context,
+                    type = "Background",
+                    detail = "${enrichedBeacons.size} beacon(s) detectado(s)"
+                )
                 dispatchToListener { it.onBeaconDetectedInBackground(enrichedBeacons.size) }
 
                 // Update foreground notification with contextual content.
@@ -324,10 +358,12 @@ class BeAroundSDK private constructor() {
 
         // v2.5 — region transitions: gate active BLE scan
         beaconManager.onRegionEnter = {
+            DetectionLogStore.append(context, type = "Região", detail = "Entrou na zona do beacon")
             dispatchToListener { it.onEnterBeaconRegion() }
         }
 
         beaconManager.onRegionExit = {
+            DetectionLogStore.append(context, type = "Região", detail = "Saiu da zona do beacon")
             dispatchToListener { it.onExitBeaconRegion() }
         }
 
@@ -1284,6 +1320,11 @@ class BeAroundSDK private constructor() {
                         // Notify listener of success
                         PushTokenStore.markSent(userDevice.pushToken)
                         DiagnosticsStore.recordSync(success = true, beaconCount = beaconsToSend.size)
+                        DetectionLogStore.append(
+                            context,
+                            type = "Sync OK",
+                            detail = "${beaconsToSend.size} beacon(s) enviados ao ingester"
+                        )
                         dispatchToListener { it.onSyncCompleted(beaconsToSend.size, success = true, error = null) }
                     },
                     onFailure = { error ->
@@ -1291,6 +1332,11 @@ class BeAroundSDK private constructor() {
                         handleSyncFailure(beaconsToSend, error, isRetry = false)
 
                         DiagnosticsStore.recordSync(success = false, beaconCount = beaconsToSend.size)
+                        DetectionLogStore.append(
+                            context,
+                            type = "Sync falhou",
+                            detail = "${beaconsToSend.size} beacon(s) · ${error.message ?: "erro desconhecido"}"
+                        )
 
                         // Notify listener of failure
                         dispatchToListener {
@@ -1353,6 +1399,11 @@ class BeAroundSDK private constructor() {
 
                 DiagnosticsStore.recordSync(success = false, beaconCount = beaconsInChunk.size)
                 DiagnosticsStore.recordError("Retry chunk failed: ${error.message}")
+                DetectionLogStore.append(
+                    context,
+                    type = "Sync falhou",
+                    detail = "${beaconsInChunk.size} beacon(s) · ${error.message ?: "erro desconhecido"}"
+                )
 
                 dispatchToListener {
                     it.onSyncCompleted(
@@ -1378,6 +1429,11 @@ class BeAroundSDK private constructor() {
 
             PushTokenStore.markSent(userDevice.pushToken)
             DiagnosticsStore.recordSync(success = true, beaconCount = beaconsInChunk.size)
+            DetectionLogStore.append(
+                context,
+                type = "Sync OK",
+                detail = "${beaconsInChunk.size} beacon(s) enviados ao ingester"
+            )
             dispatchToListener { it.onSyncCompleted(beaconsInChunk.size, success = true, error = null) }
         }
 
@@ -1460,6 +1516,21 @@ class BeAroundSDK private constructor() {
      * [DiagnosticsStore] (recent scan/sync outcomes and errors). Safe to call at any
      * time; values are best-effort and reflect what the SDK has observed so far.
      */
+    /**
+     * Persisted detection log as a JSON array string (newest first), each entry
+     * `{id, timestamp, state, type, detail}` where `state` is one of
+     * `foreground` / `background` / `backgroundLocked` / `terminated`.
+     *
+     * It survives process death, so it is the way to answer "did the SDK detect
+     * anything while the app was closed?" — those entries carry `terminated`.
+     *
+     * Same contract as the iOS SDK's `getDetectionLogJson()`.
+     */
+    fun getDetectionLogJson(): String = DetectionLogStore.readJson(context)
+
+    /** Clears the persisted detection log. Mirrors iOS `clearDetectionLog()`. */
+    fun clearDetectionLog() = DetectionLogStore.clear(context)
+
     fun diagnostics(): BeAroundDiagnostics {
         val hasBtScan = ::beaconManager.isInitialized && beaconManager.hasBluetoothScanPermission()
         return BeAroundDiagnostics(

--- a/sdk/src/main/java/io/bearound/sdk/utilities/AppStateMonitor.kt
+++ b/sdk/src/main/java/io/bearound/sdk/utilities/AppStateMonitor.kt
@@ -1,0 +1,109 @@
+package io.bearound.sdk.utilities
+
+import android.app.Activity
+import android.app.Application
+import android.app.KeyguardManager
+import android.content.Context
+import android.os.Bundle
+import android.os.PowerManager
+
+/**
+ * Best-effort classification of the PROCESS state at write time, so persisted
+ * detections can say *how* the app was running when they happened:
+ *
+ *  - `foreground` — an Activity is resumed
+ *  - `background` — the app ran the UI before, but no Activity is resumed now
+ *  - `backgroundLocked` — same as background, with the device screen LOCKED
+ *  - `terminated` — the process is alive but the UI NEVER became active: it was
+ *    started by the system (broadcast-delivered BLE scan result, boot receiver,
+ *    watchdog alarm) while the app was closed. This is the Android counterpart
+ *    of an iOS state-restoration relaunch, and the only tag that answers
+ *    "did the SDK work with the app closed?".
+ *
+ * The `terminated` heuristic is the same one the iOS SDK uses ("process alive,
+ * UI never active"), which keeps both platforms reporting the same thing.
+ *
+ * Mirrors the iOS `AppStateMonitor`.
+ */
+internal object AppStateMonitor {
+
+    enum class Tag(val raw: String) {
+        FOREGROUND("foreground"),
+        BACKGROUND("background"),
+        BACKGROUND_LOCKED("backgroundLocked"),
+        TERMINATED("terminated"),
+    }
+
+    private val lock = Any()
+    private var initialized = false
+    private var resumedActivities = 0
+
+    /** True once ANY Activity of this process resumed — the terminated discriminator. */
+    private var wasEverActive = false
+
+    private var appContext: Context? = null
+
+    /**
+     * Registers the Activity lifecycle observer. Safe to call repeatedly and from
+     * any thread; a host without an Application context (rare, e.g. some test
+     * harnesses) simply keeps the default classification.
+     */
+    fun install(context: Context) {
+        val app = context.applicationContext as? Application ?: return
+        synchronized(lock) {
+            if (initialized) return
+            initialized = true
+            appContext = app
+        }
+        app.registerActivityLifecycleCallbacks(object : Application.ActivityLifecycleCallbacks {
+            override fun onActivityResumed(activity: Activity) {
+                synchronized(lock) {
+                    resumedActivities++
+                    wasEverActive = true
+                }
+            }
+
+            override fun onActivityPaused(activity: Activity) {
+                synchronized(lock) { if (resumedActivities > 0) resumedActivities-- }
+            }
+
+            override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) = Unit
+            override fun onActivityStarted(activity: Activity) = Unit
+            override fun onActivityStopped(activity: Activity) = Unit
+            override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) = Unit
+            override fun onActivityDestroyed(activity: Activity) = Unit
+        })
+    }
+
+    /** Current tag. Safe from any thread; never throws. */
+    fun currentTag(): Tag {
+        val (active, resumed) = synchronized(lock) { wasEverActive to resumedActivities }
+
+        // Process running without the UI ever having been active → the system
+        // started us while the app was closed.
+        if (!active) return Tag.TERMINATED
+        if (resumed > 0) return Tag.FOREGROUND
+        return if (isDeviceLocked()) Tag.BACKGROUND_LOCKED else Tag.BACKGROUND
+    }
+
+    private fun isDeviceLocked(): Boolean {
+        val ctx = synchronized(lock) { appContext } ?: return false
+        return try {
+            val keyguard = ctx.getSystemService(Context.KEYGUARD_SERVICE) as? KeyguardManager
+            val power = ctx.getSystemService(Context.POWER_SERVICE) as? PowerManager
+            keyguard?.isKeyguardLocked == true || power?.isInteractive == false
+        } catch (_: Throwable) {
+            false
+        }
+    }
+
+    @Synchronized
+    internal fun resetForTests() {
+        synchronized(lock) {
+            initialized = false
+            resumedActivities = 0
+            wasEverActive = false
+            appContext = null
+        }
+    }
+}

--- a/sdk/src/main/java/io/bearound/sdk/utilities/DetectionLogStore.kt
+++ b/sdk/src/main/java/io/bearound/sdk/utilities/DetectionLogStore.kt
@@ -1,0 +1,103 @@
+package io.bearound.sdk.utilities
+
+import android.content.Context
+import android.util.Log
+import org.json.JSONArray
+import org.json.JSONObject
+
+/**
+ * Persisted detection log — the diagnostic answer to "what did the SDK see, and
+ * with the app in which state?".
+ *
+ * Backed by SharedPreferences (the Android counterpart of iOS `UserDefaults`),
+ * so entries survive process death: a detection recorded while the app was
+ * closed is still there when the user opens it again. An in-memory mirror keeps
+ * reads cheap; the disk write is what makes `terminated` entries meaningful.
+ *
+ * Each entry carries the state at WRITE time via [AppStateMonitor] — including
+ * `terminated` for events during a system-started process (broadcast-delivered
+ * scan result / boot / watchdog) before any UI appears.
+ *
+ * Surfaced to hosts via `BeAroundSDK.getDetectionLogJson()` / `clearDetectionLog()`.
+ *
+ * Mirrors the iOS `DetectionLogStore` (same JSON shape, same tags, same cap).
+ */
+internal object DetectionLogStore {
+
+    private const val TAG = "BeAroundSDK-DetLog"
+    private const val PREFS_NAME = "bearound_sdk_log"
+    private const val STORAGE_KEY = "entries"
+    private const val MAX_ENTRIES = 500
+
+    private val lock = Any()
+    private var cache: JSONArray? = null
+    private var seq = 0
+
+    /**
+     * Appends an entry tagged with the current process state.
+     *
+     * Entries written while the app is closed (`terminated`) are flushed with
+     * `commit()` — the system may kill the process right after the wake-up
+     * callback, and an async `apply()` would lose exactly the evidence this log
+     * exists to capture. Foreground/background writes use `apply()` to stay off
+     * the hot path.
+     */
+    fun append(context: Context, type: String, detail: String) {
+        val tag = AppStateMonitor.currentTag()
+        try {
+            synchronized(lock) {
+                val prefs = context.applicationContext
+                    .getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+                val arr = cache ?: readArray(prefs).also { cache = it }
+
+                val entry = JSONObject()
+                    .put("id", "${System.currentTimeMillis()}-${seq++}")
+                    .put("timestamp", System.currentTimeMillis())
+                    .put("state", tag.raw)
+                    .put("type", type)
+                    .put("detail", detail)
+
+                val next = JSONArray().put(entry)
+                val limit = minOf(arr.length(), MAX_ENTRIES - 1)
+                for (i in 0 until limit) next.put(arr.get(i))
+                cache = next
+
+                val editor = prefs.edit().putString(STORAGE_KEY, next.toString())
+                if (tag == AppStateMonitor.Tag.TERMINATED) editor.commit() else editor.apply()
+            }
+        } catch (t: Throwable) {
+            // Diagnostics must never break detection.
+            Log.w(TAG, "append failed: ${t.message}")
+        }
+    }
+
+    /** The log as a JSON array string (newest first). `"[]"` when empty. */
+    fun readJson(context: Context): String = try {
+        synchronized(lock) {
+            val prefs = context.applicationContext
+                .getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            (cache ?: readArray(prefs).also { cache = it }).toString()
+        }
+    } catch (t: Throwable) {
+        Log.w(TAG, "read failed: ${t.message}")
+        "[]"
+    }
+
+    fun clear(context: Context) {
+        synchronized(lock) {
+            cache = null
+            context.applicationContext
+                .getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+                .edit().remove(STORAGE_KEY).apply()
+        }
+    }
+
+    private fun readArray(prefs: android.content.SharedPreferences): JSONArray {
+        val raw = prefs.getString(STORAGE_KEY, null) ?: return JSONArray()
+        return try {
+            JSONArray(raw)
+        } catch (_: Throwable) {
+            JSONArray()
+        }
+    }
+}

--- a/sdk/src/test/java/io/bearound/sdk/utilities/DetectionLogStoreTest.kt
+++ b/sdk/src/test/java/io/bearound/sdk/utilities/DetectionLogStoreTest.kt
@@ -1,0 +1,80 @@
+package io.bearound.sdk.utilities
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import org.json.JSONArray
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class DetectionLogStoreTest {
+
+    private lateinit var context: Context
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        DetectionLogStore.clear(context)
+        AppStateMonitor.resetForTests()
+    }
+
+    @After
+    fun tearDown() {
+        DetectionLogStore.clear(context)
+    }
+
+    @Test
+    fun `empty log reads as empty json array`() {
+        assertEquals("[]", DetectionLogStore.readJson(context))
+    }
+
+    @Test
+    fun `entry carries type detail and process state`() {
+        DetectionLogStore.append(context, type = "Scan", detail = "0.205 (-47 dBm)")
+
+        val entry = JSONArray(DetectionLogStore.readJson(context)).getJSONObject(0)
+        assertEquals("Scan", entry.getString("type"))
+        assertEquals("0.205 (-47 dBm)", entry.getString("detail"))
+        assertTrue(entry.getLong("timestamp") > 0)
+        assertTrue(entry.getString("id").isNotEmpty())
+    }
+
+    @Test
+    fun `events from a process whose UI never became active are tagged terminated`() {
+        // No Activity ever resumed — exactly the broadcast-revived process case.
+        DetectionLogStore.append(context, type = "Background", detail = "1 beacon(s)")
+
+        val entry = JSONArray(DetectionLogStore.readJson(context)).getJSONObject(0)
+        assertEquals("terminated", entry.getString("state"))
+    }
+
+    @Test
+    fun `newest entry comes first`() {
+        DetectionLogStore.append(context, type = "Scan", detail = "primeiro")
+        DetectionLogStore.append(context, type = "Scan", detail = "segundo")
+
+        val arr = JSONArray(DetectionLogStore.readJson(context))
+        assertEquals("segundo", arr.getJSONObject(0).getString("detail"))
+        assertEquals("primeiro", arr.getJSONObject(1).getString("detail"))
+    }
+
+    @Test
+    fun `log is capped so it cannot grow without bound`() {
+        repeat(520) { DetectionLogStore.append(context, type = "Scan", detail = "n$it") }
+
+        assertEquals(500, JSONArray(DetectionLogStore.readJson(context)).length())
+    }
+
+    @Test
+    fun `clear empties the log`() {
+        DetectionLogStore.append(context, type = "Scan", detail = "algo")
+        DetectionLogStore.clear(context)
+
+        assertEquals("[]", DetectionLogStore.readJson(context))
+    }
+}


### PR DESCRIPTION
## Problem

The iOS SDK's `AppStateMonitor.swift` documents *"Mirrors the Android `DetectionLogStore`"* — **that store was never implemented on Android**. The fallout was concrete:

- The Flutter plugin answered `getPersistedLog()` with a hardcoded `"[]"` on Android (an explicit iOS-only stub), so host Log screens were **always empty** — indistinguishable from "background collection is broken". That cost a full debugging session in the field.
- The native `BearoundScan` sample worked around it with an in-memory log in its ViewModel, which dies with the process, so **`terminated` could never be shown on any Android host** — while iOS has had it for releases.

Logcat is no substitute: nobody is attached when the app is closed, which is exactly the state that needs proving.

## What this adds

`utilities/AppStateMonitor.kt` — classifies the process state with the **same heuristic iOS uses** (process alive but UI never active ⇒ `terminated`), via `ActivityLifecycleCallbacks` plus `KeyguardManager`/`PowerManager` for the locked case.

`utilities/DetectionLogStore.kt` — persists to SharedPreferences (the counterpart of iOS `UserDefaults`) with an in-memory mirror for cheap reads. Identical JSON shape, 500-entry cap and `type`/`detail` strings to iOS:

| `type` | `detail` |
|---|---|
| `Scan` | `0.205 rssi=-61` (comma-joined; throttled to one entry per composition change or every 10 s) |
| `Background` | `N beacon(s) detectado(s)` |
| `Região` | `Entrou na zona do beacon` / `Saiu da zona do beacon` |
| `Sync OK` | `N beacon(s) enviados ao ingester` |
| `Sync falhou` | `N beacon(s) · <erro>` |

Two details that are not cosmetic:

- **`terminated` writes use `commit()`**, everything else `apply()` — the system may kill the process immediately after the wake-up callback, and an async write would lose the very evidence this log captures (iOS does the same with `UserDefaults.synchronize()`).
- **The 10 s scan throttle is required for parity and for usefulness**: without it a HIGH-precision scan writes several entries per second and the 500-entry window covers barely a minute.

Public API mirrors the iOS names, so wrappers need no platform branch: `getDetectionLogJson()` / `clearDetectionLog()`.

## Validation

- 6 new unit tests (empty log, entry shape, **terminated tagging for a process whose UI never became active**, ordering, 500-entry cap, clear) + full suite and lint green.
- Field-tested on a Galaxy A16 (Android 16):
  - **Background**, screen off → `FG 8 / BG 33`, with `Background`/`Scan`/`Sync OK` entries tagged `background`.
  - **Terminated**: device rebooted, app never opened → the SDK came up headless via `BOOT_COMPLETED` (zero Activity launches in the logs), detected and synced, and the log showed **5 `terminated` entries** still present when the app was finally opened.

## Documented

[docs/DETECTION-LOG.md](docs/DETECTION-LOG.md) — full contract, implementation notes, host-UI reference, field results, and the **OS limits that are not SDK limits**: Android 15+ *force stop* leaves the package stopped (no broadcasts, no PendingIntents ⇒ nothing runs, nothing to log; older versions do revive), and with the foreground service enabled the process is effectively unkillable, so `terminated` rarely appears in that configuration. The README gained a section pointing at it.
