### PR TITLE
Hardening 3.7.0 — exit de região, disciplina de quota de scan, entrega confiável

### DIFF
--- a/BearoundScan/src/main/java/io/bearound/bearoundscan/viewmodel/BeaconViewModel.kt
+++ b/BearoundScan/src/main/java/io/bearound/bearoundscan/viewmodel/BeaconViewModel.kt
@@ -380,12 +380,6 @@ class BeaconViewModel(application: Application) : AndroidViewModel(application),
         _state.value = _state.value.copy(showSettings = false)
     }
 
-    val scanDuration: Int
-        get() = (sdk.currentScanDuration ?: 0L).toInt() / 1000
-
-    val pauseDuration: Int
-        get() = (sdk.currentPauseDuration ?: 0L).toInt() / 1000
-
     val scanMode: String
         get() = when (sdk.currentScanPrecision) {
             ScanPrecision.HIGH -> "Contínuo (HIGH)"

--- a/README.md
+++ b/README.md
@@ -659,6 +659,54 @@ val batches: List<List<Beacon>> = sdk.pendingBatches
 Beacon metadata (battery, temperature, firmware, movements) arrives in the same `0xBEAD`
 service-data payload and is exposed via `Beacon.metadata`. No configuration needed.
 
+### Periodic reconciliation (WorkManager)
+
+A best-effort safety net: a unique `PeriodicWorkRequest` that periodically self-heals the
+background scan registration, waits a short collection window for the continuous scanners
+to deliver, and drains pending data through the existing sync pipeline. The
+**PendingIntent scan remains the primary detection mechanism** — this layer only
+complements it.
+
+```kotlin
+sdk.configure(
+    businessToken = "your-business-token",
+    periodicReconciliationEnabled = true,                     // default: true
+    periodicReconciliationIntervalMillis = 30L * 60L * 1000L, // default: 20 min
+    periodicScanDurationMillis = 12_000L                      // default: 12 s
+)
+```
+
+To disable the layer (the pending periodic work is cancelled):
+
+```kotlin
+sdk.configure(
+    businessToken = "your-business-token",
+    periodicReconciliationEnabled = false
+)
+```
+
+**What the interval means — read carefully.** The value is only the *minimum* interval
+between eligible executions. Android alone decides the actual timing: Doze, battery
+optimizations, WorkManager flex windows and OEM policies can all delay the worker —
+sometimes by a lot. Force-stop suspends it entirely until the app is launched again.
+Never read it as "runs every N minutes".
+
+**Guard rails.** Accepted interval range is **15 minutes (WorkManager's hard minimum for
+periodic work) to 24 hours**; the scan window accepts **3–30 seconds**. Out-of-range
+values are clamped with an ERROR-level logcat warning (never silently, never a crash —
+note that WorkManager itself silently raises sub-15-min intervals, so the SDK warns
+where the platform would stay quiet). Non-positive values fall back to the defaults.
+
+**What one execution does.** Honoring the host's intent and the device state: after
+`stopScanning()` it only drains pending data (never touches scan state); in Battery
+Saver or serious/critical thermal state it skips the collection window; otherwise it
+re-registers a dead PendingIntent client if needed (one budget-guarded start), waits up
+to the configured window for the continuous scanners to deliver (data already present
+short-circuits immediately), and syncs through the normal single-flight pipeline. The
+worker never registers scanners, PendingIntents, or foreground services of its own, and
+runs without any network constraint — offline it persists and completes, leaving
+delivery to the retry pipeline.
+
 ## API Reference
 
 ### BeAroundSDK
@@ -675,7 +723,10 @@ sdk.configure(
     businessToken: String,
     scanPrecision: ScanPrecision = ScanPrecision.MEDIUM,
     maxQueuedPayloads: MaxQueuedPayloads = MaxQueuedPayloads.MEDIUM,
-    technology: String = "android-native" // payload tag; wrappers override it
+    technology: String = "android-native", // payload tag; wrappers override it
+    periodicReconciliationEnabled: Boolean = true,
+    periodicReconciliationIntervalMillis: Long = 20 * 60 * 1000L, // 15 min–24 h
+    periodicScanDurationMillis: Long = 12_000L                    // 3–30 s
 )
 
 // Scanning

--- a/app/src/main/java/io/bearound/scan/BeAroundScanApp.kt
+++ b/app/src/main/java/io/bearound/scan/BeAroundScanApp.kt
@@ -468,11 +468,6 @@ fun ScanInfoCard(state: BeAroundScanState, viewModel: BeaconViewModel) {
                 valueColor = MaterialTheme.colorScheme.primary
             )
             InfoRow(label = "Intervalo de sync:", value = "${state.currentSyncInterval}s")
-            InfoRow(label = "Duração do scan:", value = "${viewModel.scanDuration}s")
-
-            if (viewModel.pauseDuration > 0) {
-                InfoRow(label = "Tempo de pausa:", value = "${viewModel.pauseDuration}s")
-            }
 
             HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
 

--- a/app/src/main/java/io/bearound/scan/BeaconViewModel.kt
+++ b/app/src/main/java/io/bearound/scan/BeaconViewModel.kt
@@ -193,12 +193,6 @@ class BeaconViewModel(application: Application) : AndroidViewModel(application),
         _state.value = _state.value.copy(beacons = sorted)
     }
 
-    val scanDuration: Int
-        get() = (sdk.currentScanDuration ?: 0L).toInt() / 1000
-
-    val pauseDuration: Int
-        get() = (sdk.currentPauseDuration ?: 0L).toInt() / 1000
-
     val scanMode: String
         get() = when (sdk.currentScanPrecision) {
             ScanPrecision.HIGH -> "Contínuo (HIGH)"

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -122,6 +122,7 @@ dependencies {
     // Context for EncryptedSharedPreferences via SecureStorage).
     testImplementation 'org.robolectric:robolectric:4.13'
     testImplementation 'androidx.test:core:1.6.1'
+    testImplementation 'androidx.work:work-testing:2.10.1'
 
     // Removed AltBeacon - using native Android Bluetooth LE APIs
     // api 'org.altbeacon:android-beacon-library:2.21.1'

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -134,7 +134,7 @@ dependencies {
     implementation 'androidx.security:security-crypto:1.1.0-alpha06'
     
     // WorkManager for periodic background sync
-    implementation 'androidx.work:work-runtime-ktx:2.9.0'
+    implementation 'androidx.work:work-runtime-ktx:2.10.1'
     
     // Gson for JSON serialization (offline batch storage)
     implementation 'com.google.code.gson:gson:2.13.2'

--- a/sdk/src/main/java/io/bearound/sdk/BeAroundSDK.kt
+++ b/sdk/src/main/java/io/bearound/sdk/BeAroundSDK.kt
@@ -26,6 +26,7 @@ import io.bearound.sdk.models.BeAroundDiagnostics
 import io.bearound.sdk.models.BeaconMetadata
 import io.bearound.sdk.models.ForegroundScanConfig
 import io.bearound.sdk.models.MaxQueuedPayloads
+import io.bearound.sdk.models.PeriodicReconciliationDefaults
 import io.bearound.sdk.models.SDKConfiguration
 import io.bearound.sdk.models.SDKInfo
 import io.bearound.sdk.models.ScanPrecision
@@ -532,11 +533,25 @@ class BeAroundSDK private constructor() {
     }
 
     /** Configures and activates the SDK. Auto-collects the FCM token if Firebase is present (see [tryAutoCollectFcmToken]). */
+    /**
+     * @param periodicReconciliationEnabled enables the periodic background reconciliation
+     *   (WorkManager layer). Best effort — Android may defer the worker (Doze, battery
+     *   optimizations, OEM policies). Default: true.
+     * @param periodicReconciliationIntervalMillis MINIMUM interval requested between
+     *   eligible executions — a floor, never a guaranteed cadence. Accepted range
+     *   **15 min (WorkManager's hard minimum) … 24 h**; out-of-range values are clamped
+     *   with an ERROR-level log; non-positive values fall back to the 20-min default.
+     * @param periodicScanDurationMillis ceiling of the collection window inside the
+     *   worker, clamped to **3–30 s**. The worker never registers scanners of its own.
+     */
     fun configure(
         businessToken: String,
         scanPrecision: ScanPrecision = ScanPrecision.MEDIUM,
         maxQueuedPayloads: MaxQueuedPayloads = MaxQueuedPayloads.MEDIUM,
-        technology: String = "android-native"
+        technology: String = "android-native",
+        periodicReconciliationEnabled: Boolean = true,
+        periodicReconciliationIntervalMillis: Long = PeriodicReconciliationDefaults.DEFAULT_INTERVAL_MILLIS,
+        periodicScanDurationMillis: Long = PeriodicReconciliationDefaults.DEFAULT_SCAN_DURATION_MILLIS
     ): BeAroundSDK {
         // NEVER-CRASH-THE-HOST: an embedded SDK must not throw from a public entry
         // point — a host wired to an empty BuildConfig field would crash on startup.
@@ -557,7 +572,12 @@ class BeAroundSDK private constructor() {
             appId = appId,
             scanPrecision = scanPrecision,
             maxQueuedPayloads = maxQueuedPayloads,
-            technology = technology
+            technology = technology,
+            periodicReconciliationEnabled = periodicReconciliationEnabled,
+            periodicReconciliationIntervalMillis =
+                PeriodicReconciliationDefaults.sanitizedInterval(periodicReconciliationIntervalMillis),
+            periodicScanDurationMillis =
+                PeriodicReconciliationDefaults.sanitizedScanDuration(periodicScanDurationMillis)
         )
 
         configuration = config
@@ -580,6 +600,12 @@ class BeAroundSDK private constructor() {
         offlineBatchStorage.currentTenantId = tenantFingerprint(businessToken)
 
         SDKConfigStorage.saveConfiguration(context, config)
+
+        // Periodic reconciliation: apply the new settings to the unique periodic work.
+        // ExistingPeriodicWorkPolicy.UPDATE swaps the spec in place (same interval =
+        // no-op churn; new interval = updated schedule) and never interrupts a worker
+        // that is already running. Disabling cancels the pending periodic work.
+        backgroundScheduler.refreshPeriodicReconciliation(config)
 
         // Error telemetry — isolated reporter ("try/catch around the library"). Own
         // try/catch: a telemetry failure must never break configure().

--- a/sdk/src/main/java/io/bearound/sdk/BeAroundSDK.kt
+++ b/sdk/src/main/java/io/bearound/sdk/BeAroundSDK.kt
@@ -45,9 +45,13 @@ import io.bearound.sdk.utilities.RegisterStore
 import io.bearound.sdk.utilities.SDKConfigStorage
 import io.bearound.sdk.utilities.SecureStorage
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock as withMutex
 import java.util.UUID
 import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.withLock
@@ -187,7 +191,16 @@ class BeAroundSDK private constructor() {
     private var syncRunnable: Runnable? = null
     private var scanRefreshRunnable: Runnable? = null
 
-    private var isSyncing = false
+    /**
+     * Single-flight sync. Every trigger (timer, workers, FCM, watchdog, broadcast flush,
+     * manual stop) funnels through [syncBeaconsAwait]; concurrent callers JOIN the
+     * in-flight operation and await its REAL result. Replaces the old `isSyncing`
+     * Boolean, which had a check-then-set window two callers could both pass, and
+     * reported a fake `true` to any caller that arrived mid-sync.
+     */
+    private val syncMutex = Mutex()
+    private var activeSync: Deferred<Boolean>? = null
+
     private lateinit var offlineBatchStorage: OfflineBatchStorage
     private var consecutiveFailures = 0
     private var lastFailureTime: Long? = null
@@ -197,7 +210,6 @@ class BeAroundSDK private constructor() {
     @Volatile private var lastImmediateFlushAt = 0L
 
     private var isInBackground = false
-    private val isColdStart = true
     private var foregroundScanConfig: ForegroundScanConfig? = null
     private val registerInFlight = java.util.concurrent.atomic.AtomicBoolean(false)
 
@@ -218,17 +230,8 @@ class BeAroundSDK private constructor() {
     val currentSyncInterval: Long?
         get() = configuration?.syncInterval
 
-    val currentScanDuration: Long?
-        get() = configuration?.precisionScanDuration
-
     val currentScanPrecision: ScanPrecision?
         get() = configuration?.scanPrecision
-
-    val currentPauseDuration: Long?
-        get() = configuration?.precisionPauseDuration
-
-    val isPeriodicScanningEnabled: Boolean
-        get() = configuration?.scanPrecision != ScanPrecision.HIGH
 
     val isConfigured: Boolean
         get() = configuration != null && apiClient != null
@@ -251,6 +254,8 @@ class BeAroundSDK private constructor() {
 
             // Update offline batch storage max count
             offlineBatchStorage.maxBatchCount = savedConfig.maxQueuedPayloads.value
+            // Same tenant gate as configure() — restored sessions read only their own queue.
+            offlineBatchStorage.currentTenantId = tenantFingerprint(savedConfig.businessToken)
 
             SDKConfigStorage.loadInternalId(context)?.let { savedId ->
                 if (userProperties?.internalId == null) {
@@ -272,7 +277,7 @@ class BeAroundSDK private constructor() {
         // process are tagged `terminated` instead of `background`.
         AppStateMonitor.install(context)
 
-        deviceInfoCollector = DeviceInfoCollector(context, isColdStart)
+        deviceInfoCollector = DeviceInfoCollector(context)
         beaconManager = BeaconManager(context)
         bluetoothManager = BluetoothManager(context)
         backgroundScanManager = BackgroundScanManager(context)
@@ -363,10 +368,6 @@ class BeAroundSDK private constructor() {
             dispatchToListener { it.onScanningStateChanged(isScanning) }
         }
 
-        beaconManager.onBackgroundRangingComplete = {
-            syncBeacons()
-        }
-
         // v2.5 — region transitions: gate active BLE scan
         beaconManager.onRegionEnter = {
             DetectionLogStore.append(context, type = "Região", detail = "Entrou na zona do beacon")
@@ -379,14 +380,20 @@ class BeAroundSDK private constructor() {
         }
 
         beaconManager.onActiveScanShouldStart = {
-            Log.d(TAG, "Active scan START — region entered, starting BLE central scan + duty cycle")
+            Log.d(TAG, "Active scan START — region entered, starting ranging + BLE central scan")
+            // Regular ranging ON: startRanging() early-returns while out of region, so the
+            // rising edge is the only place the first in-region ranging session can start —
+            // without this call the region ran on batch/PendingIntent alone (the doctrine
+            // comment in BeaconManager.startRanging promised this hookup all along).
+            beaconManager.resumeRanging()
             // Bluetooth metadata scan ON only while inside a region.
             bluetoothManager.startScanning()
             dispatchToListener { it.onActiveScanStateChanged(true) }
         }
 
         beaconManager.onActiveScanShouldStop = {
-            Log.d(TAG, "Active scan STOP — region exited, stopping BLE central scan")
+            Log.d(TAG, "Active scan STOP — region exited, stopping ranging + BLE central scan")
+            beaconManager.stopRanging()
             bluetoothManager.stopScanning()
             dispatchToListener { it.onActiveScanStateChanged(false) }
         }
@@ -446,15 +453,26 @@ class BeAroundSDK private constructor() {
     }
 
     private fun setupLifecycleObserver() {
-        ProcessLifecycleOwner.get().lifecycle.addObserver(object : DefaultLifecycleObserver {
-            override fun onStart(owner: LifecycleOwner) {
-                onAppForegrounded()
-            }
+        // Lifecycle.addObserver is a main-thread API. The singleton's FIRST getInstance()
+        // can come from a WorkManager thread (cold start via FCM/worker) — registering
+        // from there throws IllegalStateException. Post when off-main; the observer only
+        // feeds isInBackground, so the sub-frame registration delay is harmless.
+        val register = Runnable {
+            ProcessLifecycleOwner.get().lifecycle.addObserver(object : DefaultLifecycleObserver {
+                override fun onStart(owner: LifecycleOwner) {
+                    onAppForegrounded()
+                }
 
-            override fun onStop(owner: LifecycleOwner) {
-                onAppBackgrounded()
-            }
-        })
+                override fun onStop(owner: LifecycleOwner) {
+                    onAppBackgrounded()
+                }
+            })
+        }
+        if (android.os.Looper.myLooper() == android.os.Looper.getMainLooper()) {
+            register.run()
+        } else {
+            handler.post(register)
+        }
     }
 
     private fun onAppForegrounded() {
@@ -546,6 +564,11 @@ class BeAroundSDK private constructor() {
 
         // Update offline batch storage max count
         offlineBatchStorage.maxBatchCount = config.maxQueuedPayloads.value
+
+        // Tenant isolation: pending batches are read back only under the token they were
+        // collected for — a configure() with a DIFFERENT client's token must never drain
+        // the previous client's queue through the new credential.
+        offlineBatchStorage.currentTenantId = tenantFingerprint(businessToken)
 
         SDKConfigStorage.saveConfiguration(context, config)
 
@@ -966,38 +989,6 @@ class BeAroundSDK private constructor() {
         syncBeacons()
     }
 
-    internal fun startQuickScan() {
-        if (!isConfigured) {
-            val savedConfig = SDKConfigStorage.loadConfiguration(context)
-            if (savedConfig != null) {
-                configuration = savedConfig
-                apiClient = APIClient(savedConfig)
-                
-                val buildNumber = try {
-                    context.packageManager.getPackageInfo(context.packageName, 0).versionCode
-                } catch (e: Exception) {
-                    1
-                }
-                sdkInfo = SDKInfo(appId = savedConfig.appId, build = buildNumber, technology = savedConfig.technology)
-            } else {
-                Log.w(TAG, "Cannot start quick scan - SDK not configured")
-                return
-            }
-        }
-        
-        beaconManager.startScanning()
-        beaconManager.startRanging()
-        
-        // Always attempt Bluetooth scanning
-        bluetoothManager.startScanning()
-    }
-
-    internal fun stopQuickScan() {
-        beaconManager.stopScanning()
-        bluetoothManager.stopScanning()
-        syncBeacons()
-    }
-
     internal fun processBroadcastResults(
         scanResults: List<ScanResult>,
         onFlushSettled: (() -> Unit)? = null
@@ -1268,8 +1259,15 @@ class BeAroundSDK private constructor() {
      * still in flight. Returns false only on a failed upload (so workers can retry).
      */
     internal suspend fun syncBeaconsAwait(forceBackground: Boolean = false): Boolean {
-            if (isSyncing) return true
+        val operation = syncMutex.withMutex {
+            activeSync?.takeIf { it.isActive }
+                ?: scope.async { performSyncOnce(forceBackground) }.also { activeSync = it }
+        }
+        return operation.await()
+    }
 
+    /** The actual sync body — reached only via the single-flight gate above. */
+    private suspend fun performSyncOnce(forceBackground: Boolean): Boolean {
             // Register retry piggyback: if the first register failed (e.g. the app launched
             // offline), nothing else would retry it while the process lives — the TTL gate
             // makes this a no-op once registered.
@@ -1287,9 +1285,9 @@ class BeAroundSDK private constructor() {
 
             // Check if we should retry failed batches
             if (shouldRetryFailed) {
-                val allBatches = offlineBatchStorage.loadAllBatches()
-                if (allBatches.isNotEmpty()) {
-                    return syncRetryBatchesInChunks(allBatches, client, info, forceBackground)
+                val allRecords = offlineBatchStorage.loadAllRecords()
+                if (allRecords.isNotEmpty()) {
+                    return syncRetryBatchesInChunks(allRecords, client, info, forceBackground)
                 }
             }
 
@@ -1311,7 +1309,17 @@ class BeAroundSDK private constructor() {
             // Record the scan result (beacons collected from scanning this window).
             DiagnosticsStore.recordScan(beaconsToSend.size)
 
-            isSyncing = true
+            // Persist-BEFORE-send: a durable copy exists before the POST leaves, so a
+            // process death mid-request can no longer lose the batch (the old flow only
+            // saved AFTER a failure callback — death between send and callback = data
+            // gone). On success the exact id is removed; on failure the batch is already
+            // on disk for the retry drain. A lost 2xx response re-sends the batch — the
+            // known at-least-once trade-off until the backend dedupe lands.
+            val persistedBatchId = offlineBatchStorage.saveBatchReturningId(beaconsToSend)
+            if (persistedBatchId == null) {
+                Log.e(TAG, "Persist-before-send failed — batch has no durable copy (upload proceeds)")
+                DiagnosticsStore.recordError("persist-before-send: saveBatch returned null")
+            }
 
             // Notify listener that sync is starting
             dispatchToListener { it.onSyncStarted(beaconsToSend.size) }
@@ -1331,13 +1339,15 @@ class BeAroundSDK private constructor() {
             // so syncOk is settled by the time we return it.
             var syncOk = false
             client.sendBeacons(beaconsToSend, info, userDevice, userProperties) { result ->
-                isSyncing = false
-
                 result.fold(
                     onSuccess = {
                         syncOk = true
                         consecutiveFailures = 0
                         lastFailureTime = null
+
+                        // Delivered — drop the durable copy so the retry drain never
+                        // re-sends this exact batch.
+                        persistedBatchId?.let { offlineBatchStorage.removeBatch(it) }
 
                         // Mark synced beacons and schedule removal after 30s
                         val syncedIds = beaconsToSend.map { it.identifier }
@@ -1393,7 +1403,9 @@ class BeAroundSDK private constructor() {
                     },
                     onFailure = { error ->
                         Log.e(TAG, "Sync failed: ${error.message}")
-                        handleSyncFailure(beaconsToSend, error, isRetry = false)
+                        // alreadyPersisted: persist-before-send wrote the durable copy up
+                        // front — only fall back to saving here when THAT write failed.
+                        handleSyncFailure(beaconsToSend, error, alreadyPersisted = persistedBatchId != null)
 
                         DiagnosticsStore.recordSync(success = false, beaconCount = beaconsToSend.size)
                         DetectionLogStore.append(
@@ -1422,13 +1434,11 @@ class BeAroundSDK private constructor() {
      * Returns false when a chunk failed (callers with an execution window can retry).
      */
     private suspend fun syncRetryBatchesInChunks(
-        allBatches: List<List<Beacon>>,
+        allRecords: List<OfflineBatchStorage.StoredBatchRecord>,
         client: APIClient,
         info: SDKInfo,
         forceBackground: Boolean
     ): Boolean {
-        isSyncing = true
-
         val locationPermission = getLocationPermissionStatus()
         val bluetoothState = if (bluetoothManager.isPoweredOn) "powered_on" else "powered_off"
         val isAppInBackground = if (forceBackground) true else isInBackground
@@ -1439,11 +1449,11 @@ class BeAroundSDK private constructor() {
             appInForeground = !isAppInBackground
         )
 
-        val chunks = allBatches.chunked(5)
-        Log.d(TAG, "Retrying ${allBatches.size} batches in ${chunks.size} chunk(s) of up to 5")
+        val chunks = allRecords.chunked(5)
+        Log.d(TAG, "Retrying ${allRecords.size} batches in ${chunks.size} chunk(s) of up to 5")
 
         for ((chunkIndex, chunk) in chunks.withIndex()) {
-            val beaconsInChunk = chunk.flatten()
+            val beaconsInChunk = chunk.flatMap { it.beacons }
             if (beaconsInChunk.isEmpty()) continue
 
             Log.d(TAG, "Sending retry chunk ${chunkIndex + 1}/${chunks.size} — ${beaconsInChunk.size} beacons from ${chunk.size} batch(es)")
@@ -1479,18 +1489,18 @@ class BeAroundSDK private constructor() {
                     it.onError(error as? Exception ?: Exception(error.message))
                 }
 
-                isSyncing = false
                 return false
             }
 
-            // Chunk succeeded — remove these batches from storage (oldest first)
+            // Chunk succeeded — remove EXACTLY the batches this chunk carried, by id.
+            // The old positional removal (`repeat(chunk.size) { removeOldestBatch() }`)
+            // deleted whatever happened to be oldest at removal time — a save/expiry
+            // between load and remove could delete an UNSENT batch instead.
             consecutiveFailures = 0
             lastFailureTime = null
-            repeat(chunk.size) {
-                offlineBatchStorage.removeOldestBatch()
-            }
+            val removed = offlineBatchStorage.removeBatches(chunk.map { it.id })
 
-            Log.d(TAG, "Retry chunk ${chunkIndex + 1}/${chunks.size} succeeded — removed ${chunk.size} batch(es)")
+            Log.d(TAG, "Retry chunk ${chunkIndex + 1}/${chunks.size} succeeded — removed $removed batch(es)")
 
             PushTokenStore.markSent(userDevice.pushToken)
             DiagnosticsStore.recordSync(success = true, beaconCount = beaconsInChunk.size)
@@ -1502,19 +1512,26 @@ class BeAroundSDK private constructor() {
             dispatchToListener { it.onSyncCompleted(beaconsInChunk.size, success = true, error = null) }
         }
 
-        isSyncing = false
         Log.d(TAG, "All retry chunks completed — storage now has ${offlineBatchStorage.getBatchCount()} batch(es)")
         return true
     }
 
-    private fun handleSyncFailure(beacons: List<Beacon>, error: Throwable, isRetry: Boolean) {
+    /** SHA-256 of the business token, truncated — batch files record it, never the raw token. */
+    private fun tenantFingerprint(businessToken: String): String =
+        java.security.MessageDigest.getInstance("SHA-256")
+            .digest(businessToken.toByteArray(Charsets.UTF_8))
+            .joinToString("") { "%02x".format(it) }
+            .take(16)
+
+    private fun handleSyncFailure(beacons: List<Beacon>, error: Throwable, alreadyPersisted: Boolean) {
         consecutiveFailures++
         lastFailureTime = System.currentTimeMillis()
 
         DiagnosticsStore.recordError("Sync failed: ${error.message}")
 
-        // Save to persistent storage (only if not already a retry)
-        if (!isRetry) {
+        // Persist-before-send already wrote the durable copy for the regular path; this
+        // save is only the fallback for the rare case that write itself failed.
+        if (!alreadyPersisted) {
             val saved = offlineBatchStorage.saveBatch(beacons)
             if (saved) {
                 Log.d(TAG, "Saved failed batch to persistent storage (total: ${offlineBatchStorage.getBatchCount()})")
@@ -1556,7 +1573,9 @@ class BeAroundSDK private constructor() {
      * Used by WorkManager to decide if sync is needed
      */
     internal fun hasPendingBeacons(): Boolean {
-        val hasCollected = beaconLock.withLock { collectedBeacons.isNotEmpty() }
+        // Only UNSYNCED beacons count — a map full of alreadySynced entries awaiting
+        // their 30s display-cleanup used to keep scheduling sync workers for nothing.
+        val hasCollected = beaconLock.withLock { collectedBeacons.values.any { !it.alreadySynced } }
         val hasStored = offlineBatchStorage.getBatchCount() > 0
         return hasCollected || hasStored
     }
@@ -1573,7 +1592,7 @@ class BeAroundSDK private constructor() {
      * Useful for debugging and retry queue visualization
      */
     val pendingBatches: List<List<Beacon>>
-        get() = offlineBatchStorage.loadAllBatches()
+        get() = offlineBatchStorage.loadAllRecords().map { it.beacons }
 
     /**
      * Returns a point-in-time snapshot of SDK state for diagnostics/support.

--- a/sdk/src/main/java/io/bearound/sdk/BeAroundSDK.kt
+++ b/sdk/src/main/java/io/bearound/sdk/BeAroundSDK.kt
@@ -31,6 +31,7 @@ import io.bearound.sdk.models.SDKInfo
 import io.bearound.sdk.models.ScanPrecision
 import io.bearound.sdk.models.UserProperties
 import io.bearound.sdk.network.APIClient
+import io.bearound.sdk.network.HttpException
 import io.bearound.sdk.telemetry.ErrorReporter
 import io.bearound.sdk.utilities.BackgroundReliabilityHelper
 import io.bearound.sdk.utilities.OemPowerProfile
@@ -67,6 +68,14 @@ class BeAroundSDK private constructor() {
 
         /** Scan-log throttle window — same 10 s the iOS SDK uses. */
         private const val SCAN_LOG_THROTTLE_MS = 10_000L
+
+        /**
+         * Statuses where an identical retry fails identically: the payload/credential is
+         * the problem, not the transport. 413 lands here too — if a SINGLE batch still
+         * exceeds the limit it is malformed, not splittable. Everything else (408, 429,
+         * 5xx, transport errors) is treated as transient and retried whole.
+         */
+        private val PERMANENT_HTTP_CODES = setOf(400, 401, 403, 404, 413, 422)
 
         /**
          * Minimum gap between broadcast-triggered background flushes. Beacons
@@ -610,12 +619,22 @@ class BeAroundSDK private constructor() {
         override fun onReceive(ctx: Context?, intent: android.content.Intent?) {
             if (intent?.action != android.bluetooth.BluetoothAdapter.ACTION_STATE_CHANGED) return
             val state = intent.getIntExtra(android.bluetooth.BluetoothAdapter.EXTRA_STATE, -1)
-            if (state == android.bluetooth.BluetoothAdapter.STATE_ON &&
-                ::beaconManager.isInitialized && wasScanningEnabled()
-            ) {
-                Log.i(TAG, "Bluetooth back ON — re-arming scan clients")
-                beaconManager.onBluetoothRestored()
-                backgroundScanManager.refreshBackgroundScanning()
+            if (!::beaconManager.isInitialized) return
+            when (state) {
+                android.bluetooth.BluetoothAdapter.STATE_OFF -> {
+                    // Drop the metadata scan's local flag now — the stack already
+                    // dropped the client. Without this, STATE_ON's re-arm hit the
+                    // "Already scanning" early-return and the scan stayed a zombie.
+                    bluetoothManager.onBluetoothPoweredOff()
+                }
+                android.bluetooth.BluetoothAdapter.STATE_ON -> {
+                    if (wasScanningEnabled()) {
+                        Log.i(TAG, "Bluetooth back ON — re-arming scan clients")
+                        beaconManager.onBluetoothRestored()
+                        bluetoothManager.onBluetoothRestored()
+                        backgroundScanManager.refreshBackgroundScanning()
+                    }
+                }
             }
         }
     }
@@ -1467,29 +1486,82 @@ class BeAroundSDK private constructor() {
 
             if (chunkResult?.isFailure == true) {
                 val error = chunkResult!!.exceptionOrNull()!!
-                Log.e(TAG, "Retry chunk ${chunkIndex + 1}/${chunks.size} failed: ${error.message}")
+                val status = (error as? HttpException)?.statusCode
+                val isPermanent = status != null && status in PERMANENT_HTTP_CODES
 
-                consecutiveFailures++
-                lastFailureTime = System.currentTimeMillis()
+                if (!isPermanent) {
+                    // Transient (network, timeout, 408/429/5xx): stop and let the caller's
+                    // backoff retry the WHOLE queue later — nothing is lost.
+                    Log.e(TAG, "Retry chunk ${chunkIndex + 1}/${chunks.size} failed: ${error.message}")
 
-                DiagnosticsStore.recordSync(success = false, beaconCount = beaconsInChunk.size)
-                DiagnosticsStore.recordError("Retry chunk failed: ${error.message}")
-                DetectionLogStore.append(
-                    context,
-                    type = "Sync falhou",
-                    detail = "${beaconsInChunk.size} beacon(s) · ${error.message ?: "erro desconhecido"}"
-                )
+                    consecutiveFailures++
+                    lastFailureTime = System.currentTimeMillis()
 
-                dispatchToListener {
-                    it.onSyncCompleted(
-                        beaconsInChunk.size,
-                        success = false,
-                        error = error as? Exception ?: Exception(error.message)
+                    DiagnosticsStore.recordSync(success = false, beaconCount = beaconsInChunk.size)
+                    DiagnosticsStore.recordError("Retry chunk failed: ${error.message}")
+                    DetectionLogStore.append(
+                        context,
+                        type = "Sync falhou",
+                        detail = "${beaconsInChunk.size} beacon(s) · ${error.message ?: "erro desconhecido"}"
                     )
-                    it.onError(error as? Exception ?: Exception(error.message))
+
+                    dispatchToListener {
+                        it.onSyncCompleted(
+                            beaconsInChunk.size,
+                            success = false,
+                            error = error as? Exception ?: Exception(error.message)
+                        )
+                        it.onError(error as? Exception ?: Exception(error.message))
+                    }
+
+                    return false
                 }
 
-                return false
+                // Permanent rejection (400/401/403/404/413/422): the backend is healthy but
+                // SOME batch in this chunk is poison — an identical retry fails identically,
+                // and stopping here let one bad batch block the whole queue for 7 days
+                // (head-of-line blocking; field case: the 3.4.5 422-rejected payloads).
+                // Bisect: send each batch alone, quarantine the rejected one(s), keep going.
+                // NOT counted as consecutiveFailures — the API is reachable.
+                Log.w(TAG, "Retry chunk ${chunkIndex + 1}/${chunks.size} rejected permanently (HTTP $status) — bisecting ${chunk.size} batch(es)")
+                var delivered = 0
+                for (record in chunk) {
+                    var singleResult: Result<Unit>? = null
+                    client.sendBeacons(record.beacons, info, userDevice, userProperties) { r ->
+                        singleResult = r
+                    }
+                    val singleStatus = (singleResult?.exceptionOrNull() as? HttpException)?.statusCode
+                    when {
+                        singleResult?.isSuccess == true -> {
+                            offlineBatchStorage.removeBatch(record.id)
+                            delivered += record.beacons.size
+                        }
+                        singleStatus != null && singleStatus in PERMANENT_HTTP_CODES -> {
+                            DiagnosticsStore.recordError("Batch quarantined (HTTP $singleStatus): ${record.id}")
+                            DetectionLogStore.append(
+                                context,
+                                type = "Sync falhou",
+                                detail = "batch rejeitado pelo backend (HTTP $singleStatus) — quarentenado"
+                            )
+                            offlineBatchStorage.quarantineBatch(record.id)
+                        }
+                        else -> {
+                            // Network blinked mid-bisect: stop; everything left stays queued.
+                            return false
+                        }
+                    }
+                }
+                if (delivered > 0) {
+                    PushTokenStore.markSent(userDevice.pushToken)
+                    DiagnosticsStore.recordSync(success = true, beaconCount = delivered)
+                    DetectionLogStore.append(
+                        context,
+                        type = "Sync OK",
+                        detail = "$delivered beacon(s) enviados ao ingester (após bisect)"
+                    )
+                    dispatchToListener { it.onSyncCompleted(delivered, success = true, error = null) }
+                }
+                continue
             }
 
             // Chunk succeeded — remove EXACTLY the batches this chunk carried, by id.

--- a/sdk/src/main/java/io/bearound/sdk/BeaconManager.kt
+++ b/sdk/src/main/java/io/bearound/sdk/BeaconManager.kt
@@ -141,7 +141,6 @@ class BeaconManager(private val context: Context) {
     var onBeaconsUpdated: ((List<Beacon>) -> Unit)? = null
     var onError: ((Exception) -> Unit)? = null
     var onScanningStateChanged: ((Boolean) -> Unit)? = null
-    var onBackgroundRangingComplete: (() -> Unit)? = null
 
     // v2.5 — Region transition + active-scan gating callbacks
     /** Fired when the first beacon is detected (rising edge: empty → ≥1). */
@@ -178,7 +177,6 @@ class BeaconManager(private val context: Context) {
     private var staleThresholdMs: Long = STALE_THRESHOLD_MS
     
     private var lastBeaconUpdate: Long? = null
-    private var emptyBeaconCount = 0
     private var rangingRestartCount = 0
     private var lastRangingRestartTime: Long? = null
 
@@ -348,6 +346,8 @@ class BeaconManager(private val context: Context) {
     /** Stop+start the ranging client so the scan mode matches the current app state. */
     @SuppressLint("MissingPermission")
     private fun restartRangingForModeChange() {
+        // Reserve the replacement's quota BEFORE killing the current session; the token
+        // acquired here is the one startRanging() spends (budgetAlreadyAcquired).
         if (!ScanStartBudget.tryAcquire("ranging-mode-flip")) return
         try {
             bluetoothLeScanner?.stopScan(scanCallback)
@@ -355,7 +355,7 @@ class BeaconManager(private val context: Context) {
             /* session already gone in the stack — the start below recreates it */
         }
         isRanging = false
-        startRanging()
+        startRanging(budgetAlreadyAcquired = true)
         Log.d(TAG, "Ranging re-registered for app-state change (foreground=$isInForeground)")
     }
 
@@ -471,13 +471,19 @@ class BeaconManager(private val context: Context) {
         lastBeaconSeenAt = null
 
         isInBeaconRegion = false
-        emptyBeaconCount = 0
         isScanning = false
         onScanningStateChanged?.invoke(false)
     }
 
+    /**
+     * @param budgetAlreadyAcquired true when the caller already holds a [ScanStartBudget]
+     *   token for this start (restart paths reserve BEFORE stopping the current session —
+     *   never kill a working scan without the replacement's quota in hand). Prevents the
+     *   double-spend where a restart consumed one token for the flip and this method
+     *   consumed a second one for the actual start.
+     */
     @SuppressLint("MissingPermission")
-    fun startRanging() {
+    fun startRanging(budgetAlreadyAcquired: Boolean = false) {
         if (!isScanning) return
         if (isRanging) return
         // Doctrine: active ranging only runs inside a beacon region. Outside, only
@@ -520,7 +526,7 @@ class BeaconManager(private val context: Context) {
 
         // Preventive quota guard: skipping one duty-cycle tick is recoverable (the next
         // tick retries in seconds); exceeding the OS quota silently starves the client.
-        if (!ScanStartBudget.tryAcquire("ranging")) return
+        if (!budgetAlreadyAcquired && !ScanStartBudget.tryAcquire("ranging")) return
 
         try {
             bluetoothLeScanner?.startScan(filters, settings, scanCallback)
@@ -551,19 +557,8 @@ class BeaconManager(private val context: Context) {
     }
 
     /**
-     * Pause ranging without changing isScanning lifecycle.
-     * Used for duty cycle pause periods.
-     */
-    @SuppressLint("MissingPermission")
-    fun pauseRanging() {
-        if (!isScanning || !isRanging) return
-        Log.d(TAG, "pauseRanging() - pausing for duty cycle")
-        stopRanging()
-    }
-
-    /**
      * Resume ranging without changing isScanning lifecycle.
-     * Used for duty cycle scan periods.
+     * Used on the region rising edge (onActiveScanShouldStart) and recovery paths.
      */
     fun resumeRanging() {
         if (!isScanning || isRanging) return
@@ -600,11 +595,11 @@ class BeaconManager(private val context: Context) {
      * payload, so [processScanResult]/[IBeaconParser.parseServiceData] handle it unchanged.
      */
     @SuppressLint("MissingPermission")
-    private fun startSlowBeaconBatchScan() {
+    private fun startSlowBeaconBatchScan(budgetAlreadyAcquired: Boolean = false) {
         if (isBatchScanning) return
         val scanner = bluetoothLeScanner ?: return
         // Preventive quota guard — the liveness check in checkRangingHealth retries later.
-        if (!ScanStartBudget.tryAcquire("batch")) return
+        if (!budgetAlreadyAcquired && !ScanStartBudget.tryAcquire("batch")) return
         try {
             // Field observability: offloaded batching is the premise of this scan — log where
             // the device only emulates it in software, so "batch didn't help" is diagnosable.
@@ -739,7 +734,6 @@ class BeaconManager(private val context: Context) {
     private fun processBeacon(beacon: Beacon) {
         val now = System.currentTimeMillis()
         lastBeaconUpdate = now
-        emptyBeaconCount = 0
 
         // Rising-edge detection: were we OUT of region before this beacon arrived?
         val wasOutOfRegion = !isInBeaconRegion
@@ -799,8 +793,7 @@ class BeaconManager(private val context: Context) {
     /** Removes timed-out beacons from the detected map. Returns true when any was removed. */
     private fun cleanupExpiredBeacons(): Boolean {
         var removedAny = false
-        val (hadBeaconsBefore, hasBeaconsAfter) = beaconLock.withLock {
-            val before = detectedBeacons.isNotEmpty()
+        val hasBeaconsAfter = beaconLock.withLock {
             val now = System.currentTimeMillis()
             val expiredKeys = beaconLastSeen.filter { (_, lastSeen) ->
                 now - lastSeen > beaconTimeout
@@ -814,16 +807,19 @@ class BeaconManager(private val context: Context) {
                 rssiAccumulators.remove(key)
             }
             removedAny = expiredKeys.isNotEmpty()
-            Pair(before, detectedBeacons.isNotEmpty())
+            detectedBeacons.isNotEmpty()
         }
 
-        // Falling-edge detection: only fire region exit after the cleanup-immune grace
-        // (ZONE_EXIT_GRACE_MS = 5 min) has elapsed since the LAST advert. Previously this
-        // fired as soon as the per-beacon `beaconTimeout` (5-65s) drained the dict —
-        // producing phantom EXIT→ENTER cycles when OS-level background scan throttling
-        // silenced delivery briefly. Now the dict can empty without triggering exit;
-        // exit fires only when no advert has arrived for ZONE_EXIT_GRACE_MS.
-        if (hadBeaconsBefore && !hasBeaconsAfter && isInBeaconRegion) {
+        // Falling-edge detection, LEVEL-triggered: exit fires whenever the map is empty,
+        // we still believe we're in-region, and no advert has arrived for
+        // ZONE_EXIT_GRACE_MS (cleanup-immune timeline — the per-beacon `beaconTimeout`
+        // of 5-65s drains the dict long before the 5-min grace elapses, and that's fine).
+        // The previous edge-triggered form (`hadBeaconsBefore && !hasBeaconsAfter`) only
+        // evaluated on the exact tick the map drained; when the grace hadn't elapsed YET
+        // on that tick, every later tick saw hadBeaconsBefore=false and the exit never
+        // fired again — isInBeaconRegion stuck true forever, metadata scan never stopped,
+        // host never got onExitBeaconRegion.
+        if (!hasBeaconsAfter && isInBeaconRegion) {
             val last = lastBeaconSeenAt
             val graceElapsed = last == null || (System.currentTimeMillis() - last) > ZONE_EXIT_GRACE_MS
             if (graceElapsed) {
@@ -836,7 +832,7 @@ class BeaconManager(private val context: Context) {
                 stopRegionCleanupTimer()
             } else {
                 val sinceLast = if (last != null) (System.currentTimeMillis() - last) / 1000 else -1
-                Log.d(TAG, "Detected map drained but zone-exit grace not yet elapsed (${sinceLast}s since last ad, grace=${ZONE_EXIT_GRACE_MS / 1000}s) — staying in region")
+                Log.d(TAG, "Detected map empty but zone-exit grace not yet elapsed (${sinceLast}s since last ad, grace=${ZONE_EXIT_GRACE_MS / 1000}s) — staying in region")
             }
         }
         return removedAny
@@ -941,13 +937,14 @@ class BeaconManager(private val context: Context) {
 
     /**
      * Re-registra o batch scan (anti-downgrade) — par do BluetoothManager.restartScanning().
-     * Se o ScanStartBudget negar o re-start, isBatchScanning fica false e o próprio
-     * watchdog ([checkRangingHealth]) re-arma no próximo ciclo — sem estado perdido.
+     * Reserva a quota do substituto ANTES de derrubar a sessão atual; sem folga no
+     * [ScanStartBudget] a sessão vigente é mantida e o watchdog re-tenta no próximo ciclo.
      */
     fun refreshBatchScan() {
         if (!isScanning || !isBatchScanning) return
+        if (!ScanStartBudget.tryAcquire("batch-refresh")) return
         stopSlowBeaconBatchScan()
-        startSlowBeaconBatchScan()
+        startSlowBeaconBatchScan(budgetAlreadyAcquired = true)
     }
 
     private fun checkRangingHealth() {
@@ -960,9 +957,13 @@ class BeaconManager(private val context: Context) {
         if (!isBatchScanning) {
             startSlowBeaconBatchScan()
         } else if (System.currentTimeMillis() - lastBatchDeliveryAt > BATCH_LIVENESS_TIMEOUT_MS) {
-            Log.w(TAG, "Batch scan silent for ${BATCH_LIVENESS_TIMEOUT_MS / 1000}s — reviving")
-            stopSlowBeaconBatchScan()
-            startSlowBeaconBatchScan()
+            // Same reserve-before-kill rule as refreshBatchScan(): a silent client is
+            // still registered — only replace it when the replacement's quota is in hand.
+            if (ScanStartBudget.tryAcquire("batch-revive")) {
+                Log.w(TAG, "Batch scan silent for ${BATCH_LIVENESS_TIMEOUT_MS / 1000}s — reviving")
+                stopSlowBeaconBatchScan()
+                startSlowBeaconBatchScan(budgetAlreadyAcquired = true)
+            }
         }
 
         if (!isInBeaconRegion) return
@@ -1006,6 +1007,11 @@ class BeaconManager(private val context: Context) {
         rangingRestartCount++
         lastRangingRestartTime = now
 
+        // Reserve the replacement's quota BEFORE stopping. If there's no headroom, keep
+        // the current session (even a possibly-dead one — without quota we couldn't
+        // recreate it anyway) and let the next watchdog tick retry with fresh budget.
+        if (!ScanStartBudget.tryAcquire("ranging-restart")) return
+
         if (isRanging) {
             bluetoothLeScanner?.stopScan(scanCallback)
         }
@@ -1013,7 +1019,7 @@ class BeaconManager(private val context: Context) {
         val backoffDelay = minOf(500L * rangingRestartCount, 5000L)
 
         handler.postDelayed({
-            startRanging()
+            startRanging(budgetAlreadyAcquired = true)
         }, backoffDelay)
     }
 

--- a/sdk/src/main/java/io/bearound/sdk/BeaconManager.kt
+++ b/sdk/src/main/java/io/bearound/sdk/BeaconManager.kt
@@ -206,9 +206,11 @@ class BeaconManager(private val context: Context) {
 
     /**
      * Saves `(isInBeaconRegion, lastBeaconSeenAt)` to SharedPreferences. Called from the
-     * 3 transitions: rising edge in [processBeacon], falling edge in [cleanupExpiredBeacons],
-     * and [stopScanning] (clean wipe). `apply()` is async so this is cheap to call from
-     * the scan/lock paths.
+     * 3 transitions (rising edge in [processBeacon], falling edge in
+     * [cleanupExpiredBeacons], [stopScanning]) plus a throttled refresh during long
+     * in-zone stays — without the refresh, a process kill after hours in the zone
+     * restored a lastSeen from the ENTER, forcing a spurious exit→enter cycle on
+     * relaunch. `apply()` is async so this is cheap to call from the scan/lock paths.
      */
     private fun persistZoneState() {
         val editor = zoneStatePrefs().edit()
@@ -221,7 +223,14 @@ class BeaconManager(private val context: Context) {
             editor.remove(PREF_KEY_ZONE_LAST_SEEN)
         }
         editor.apply()
+        lastZonePersistedAt = System.currentTimeMillis()
     }
+
+    /** Last persistZoneState() wall-clock, for the in-zone refresh throttle. */
+    private var lastZonePersistedAt = 0L
+
+    /** Refresh cadence of the persisted lastBeaconSeenAt while inside the zone. */
+    private val zonePersistThrottleMs = 60_000L
 
     /**
      * Restores the persisted snapshot at construction. Only honors `inZone=true` snapshots
@@ -426,6 +435,18 @@ class BeaconManager(private val context: Context) {
                 Log.d(TAG, "Zone state fresh (${(System.currentTimeMillis() - last) / 1000}s since last ad) — re-arming active scan")
                 startRegionCleanupTimer()
                 onActiveScanShouldStart?.invoke()
+            } else if (isInBeaconRegion) {
+                // Restored "inside" but the last DETECTION is already past the exit grace
+                // (the restore gate validates the snapshot's write age, not the ad age).
+                // Keeping inside here created the "inside but passive" trap: no cleanup
+                // timer running (so the level-triggered exit never evaluates), and the
+                // next advert doesn't fire a rising edge (wasOutOfRegion=false) — active
+                // scanners stay off with the device physically in the zone. Transition to
+                // OUTSIDE so the next advert produces a clean ENTER with full re-arm.
+                Log.d(TAG, "Restored zone is stale (last ad ${if (last != null) (System.currentTimeMillis() - last) / 1000 else -1}s ago) — transitioning to outside")
+                isInBeaconRegion = false
+                lastBeaconSeenAt = null
+                persistZoneState()
             }
 
         } catch (e: Exception) {
@@ -746,6 +767,12 @@ class BeaconManager(private val context: Context) {
         }
         // Cleanup-immune "any beacon seen at" timeline. See [lastBeaconSeenAt] kdoc.
         lastBeaconSeenAt = now
+
+        // Throttled refresh of the persisted snapshot during long stays, so a process
+        // kill mid-stay restores a FRESH lastSeen instead of the enter-time one.
+        if (!wasOutOfRegion && now - lastZonePersistedAt > zonePersistThrottleMs) {
+            persistZoneState()
+        }
 
         if (wasOutOfRegion) {
             Log.d(TAG, "REGION ENTER — first beacon detected (${beacon.identifier})")

--- a/sdk/src/main/java/io/bearound/sdk/BluetoothManager.kt
+++ b/sdk/src/main/java/io/bearound/sdk/BluetoothManager.kt
@@ -80,7 +80,33 @@ class BluetoothManager(private val context: Context) {
             }
             if (errorCode == 1 /* SCAN_FAILED_ALREADY_STARTED */) {
                 healZombieScanRegistration()
+                return // heal resets isScanning itself
             }
+            // Every failure code means the scan is NOT running — the flag must say so,
+            // or the next startScanning() early-returns "Already scanning" forever.
+            // Recovery is owned by the existing paths (region edges, BT restore, heal).
+            isScanning = false
+        }
+    }
+
+    /**
+     * The stack drops every scan client when the radio powers off, but this object's
+     * flag survived as a lie — the next startScanning() saw "Already scanning" and the
+     * metadata scan stayed a zombie for the rest of the region stay.
+     */
+    fun onBluetoothPoweredOff() {
+        if (isScanning) {
+            Log.d(TAG, "Bluetooth powered off — metadata scan client is gone, clearing flag")
+            isScanning = false
+        }
+    }
+
+    /** Radio back on: re-arm the metadata scan if the host still wants it (in-region). */
+    fun onBluetoothRestored() {
+        isScanning = false
+        if (desiredScanning) {
+            Log.d(TAG, "Bluetooth restored — re-arming metadata scan")
+            startScanning()
         }
     }
 

--- a/sdk/src/main/java/io/bearound/sdk/BluetoothManager.kt
+++ b/sdk/src/main/java/io/bearound/sdk/BluetoothManager.kt
@@ -35,6 +35,13 @@ class BluetoothManager(private val context: Context) {
     private var bluetoothAdapter: BluetoothAdapter? = null
     private var bluetoothLeScanner: BluetoothLeScanner? = null
     private var isScanning = false
+
+    /** Host intent: true between startScanning() and stopScanning(), regardless of whether
+     *  the scan is actually registered right now. Gate for every deferred self-heal restart. */
+    private var desiredScanning = false
+
+    /** The one cancellable self-heal restart in flight (see [healZombieScanRegistration]). */
+    private var pendingRestart: Runnable? = null
     
     private val lastSeenBeacons = mutableMapOf<String, Long>()
 
@@ -93,7 +100,16 @@ class BluetoothManager(private val context: Context) {
             /* stale registration — nothing to stop */
         }
         isScanning = false
-        handler.postDelayed({ startScanning() }, 500L)
+        // Cancellable + intent-guarded restart: stopScanning() during the 500ms window
+        // removes the callback AND flips desiredScanning, so a heal scheduled before an
+        // explicit stop can never resurrect the scan after it.
+        pendingRestart?.let { handler.removeCallbacks(it) }
+        val restart = Runnable {
+            pendingRestart = null
+            if (desiredScanning) startScanning()
+        }
+        pendingRestart = restart
+        handler.postDelayed(restart, 500L)
     }
 
     /**
@@ -120,6 +136,10 @@ class BluetoothManager(private val context: Context) {
 
     @SuppressLint("MissingPermission")
     fun startScanning() {
+        // Intent flag: survives transient start failures (BT off, missing permission,
+        // quota) so self-heal paths know the host still WANTS the scan; cleared only by
+        // an explicit stopScanning().
+        desiredScanning = true
         if (!isPoweredOn) {
             Log.w(TAG, "Cannot start scanning - Bluetooth not powered on")
             listener?.onBluetoothStateChanged(false)
@@ -188,54 +208,24 @@ class BluetoothManager(private val context: Context) {
 
     @SuppressLint("MissingPermission")
     fun stopScanning() {
+        // Always clear the intent + any pending self-heal restart, even when isScanning
+        // is already false — a heal Runnable may be in flight for a scan that failed.
+        desiredScanning = false
+        pendingRestart?.let { handler.removeCallbacks(it) }
+        pendingRestart = null
+
         if (!isScanning) return
 
         try {
             bluetoothLeScanner?.stopScan(scanCallback)
-            isScanning = false
-            lastSeenBeacons.clear()
             Log.d(TAG, "Stopped BLE scanning")
-            
         } catch (e: Exception) {
             Log.e(TAG, "Failed to stop BLE scanning: ${e.message}")
-        }
-    }
-
-    /**
-     * Pause BLE scanning without changing isScanning lifecycle.
-     * Used for duty cycle pause periods.
-     */
-    @SuppressLint("MissingPermission")
-    fun pauseScanning() {
-        if (!isScanning) return
-        try {
-            bluetoothLeScanner?.stopScan(scanCallback)
-            Log.d(TAG, "Paused BLE scanning for duty cycle")
-        } catch (e: Exception) {
-            Log.e(TAG, "Failed to pause BLE scanning: ${e.message}")
-        }
-    }
-
-    /**
-     * Resume BLE scanning without changing isScanning lifecycle.
-     * Used for duty cycle scan periods.
-     */
-    @SuppressLint("MissingPermission")
-    fun resumeScanning() {
-        if (!isScanning) return
-        if (!checkPermissions()) return
-        // Skipping one duty-cycle tick is recoverable; starving the client is not.
-        if (!ScanStartBudget.tryAcquire("metadata-resume")) return
-        try {
-            val settings = ScanSettings.Builder()
-                // Foreground service is active -> BALANCED (not LOW_POWER) for faster detection; Android throttles anyway without a FG service.
-                .setScanMode(ScanSettings.SCAN_MODE_BALANCED)
-                .setReportDelay(0)
-                .build()
-            bluetoothLeScanner?.startScan(metadataScanFilters(), settings, scanCallback)
-            Log.d(TAG, "Resumed BLE scanning for duty cycle")
-        } catch (e: Exception) {
-            Log.e(TAG, "Failed to resume BLE scanning: ${e.message}")
+        } finally {
+            // The local flag must drop even when stopScan throws (e.g. SecurityException
+            // after a permission revoke) — a lying isScanning=true blocked every restart.
+            isScanning = false
+            lastSeenBeacons.clear()
         }
     }
 
@@ -251,7 +241,14 @@ class BluetoothManager(private val context: Context) {
         val serviceData = IBeaconParser.parseServiceData(scanRecord, rssi) ?: return
         if (!shouldProcessBeacon(serviceData.major, serviceData.minor)) return
 
-        val isConnectable = scanRecord.advertiseFlags and 0x02 != 0
+        // ScanResult.isConnectable() (API 26+) reports the actual PDU type; the old
+        // `advertiseFlags and 0x02` read the "LE General Discoverable" flag, which is
+        // discoverability — not whether the device accepts connections.
+        val isConnectable = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            result.isConnectable
+        } else {
+            scanRecord.advertiseFlags and 0x02 != 0
+        }
 
         listener?.onBeaconDiscovered(
             uuid = IBeaconParser.BEAROUND_UUID,

--- a/sdk/src/main/java/io/bearound/sdk/background/BackgroundScanManager.kt
+++ b/sdk/src/main/java/io/bearound/sdk/background/BackgroundScanManager.kt
@@ -26,10 +26,21 @@ class BackgroundScanManager(private val context: Context) {
         private const val TAG = "BeAroundSDK-BgScan"
     }
     
+    /**
+     * Set ONLY after the stack ACCEPTED the registration (startScan returned 0).
+     * The old flow assigned it before the budget check and before startScan — a denied
+     * quota then left the field non-null, [isRegistered] lied `true`, and the 35s retry
+     * (gated on `pendingIntent == null`) never re-registered anything: the only
+     * out-of-region detector stayed dead until the 15-min watchdog.
+     */
     private var pendingIntent: PendingIntent? = null
+
+    /** Host intent: true between enable and disable, regardless of registration success. */
+    private var desiredEnabled = false
+
     private var bluetoothLeScanner: BluetoothLeScanner? = null
     private val retryHandler = android.os.Handler(android.os.Looper.getMainLooper())
-    private var retryScheduled = false
+    private var pendingRetry: Runnable? = null
 
     /** True while the low-power PendingIntent background scan is registered. For diagnostics. */
     val isRegistered: Boolean
@@ -41,6 +52,7 @@ class BackgroundScanManager(private val context: Context) {
      */
     @SuppressLint("MissingPermission")
     fun enableBackgroundScanning() {
+        desiredEnabled = true
         // On Android 12+ the PendingIntent scan requires BLUETOOTH_SCAN. Without it the OS
         // throws SecurityException (caught, but it floods the log on every retry). This path
         // is reached ungated via restartScanningFromBackground, so check here too — skip
@@ -59,10 +71,14 @@ class BackgroundScanManager(private val context: Context) {
     }
 
     /**
-     * Disable background scanning
+     * Disable background scanning. Also drops the intent flag and cancels any delayed
+     * retry, so a registration deferred before the disable can't fire after it.
      */
     @SuppressLint("MissingPermission")
     fun disableBackgroundScanning() {
+        desiredEnabled = false
+        pendingRetry?.let { retryHandler.removeCallbacks(it) }
+        pendingRetry = null
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             disableBluetoothScanBroadcast()
         }
@@ -95,13 +111,15 @@ class BackgroundScanManager(private val context: Context) {
                 PendingIntent.FLAG_UPDATE_CURRENT
             }
 
-            pendingIntent = PendingIntent.getBroadcast(
+            // Created locally; published to the field ONLY after the stack accepts the
+            // scan — see [pendingIntent] for why premature assignment broke the retry.
+            val candidate = PendingIntent.getBroadcast(
                 context,
                 0,
                 intent,
                 flags
             )
-            
+
             val filters = listOf(
                 ScanFilter.Builder()
                     .setManufacturerData(
@@ -140,29 +158,32 @@ class BackgroundScanManager(private val context: Context) {
             if (!ScanStartBudget.tryAcquire("pending-intent")) {
                 // The PendingIntent scan is the ONLY out-of-region detector — waiting for the
                 // 15-min watchdog after a startup-burst deferral is too long. Retry shortly,
-                // once the 30 s budget window has rolled over.
+                // once the 30 s budget window has rolled over. The field stays null, so the
+                // retry's `pendingIntent == null` gate actually fires (the old flow had
+                // already assigned it, turning every deferral into a permanent no-op).
+                candidate.cancel()
                 scheduleRetry()
                 return
             }
 
-            pendingIntent?.let { pi ->
-                // For PendingIntent scans the SCAN_FAILED_* code comes in the RETURN VALUE —
-                // there is no callback. Ignoring it makes a failed registration (e.g. over
-                // the scan-start quota during a fg↔bg flip) permanently invisible.
-                val result = bluetoothLeScanner?.startScan(filters, settings, pi) ?: -1
-                if (result != 0) {
-                    Log.w(TAG, "PendingIntent scan registration FAILED (code $result) — retrying shortly")
-                    if (result == 6 /* SCAN_FAILED_SCANNING_TOO_FREQUENTLY */) ScanStartBudget.freeze()
-                    pi.cancel()
-                    pendingIntent = null
-                    scheduleRetry()
-                    return
-                }
+            // For PendingIntent scans the SCAN_FAILED_* code comes in the RETURN VALUE —
+            // there is no callback. Ignoring it makes a failed registration (e.g. over
+            // the scan-start quota during a fg↔bg flip) permanently invisible.
+            val result = bluetoothLeScanner?.startScan(filters, settings, candidate) ?: -1
+            if (result != 0) {
+                Log.w(TAG, "PendingIntent scan registration FAILED (code $result) — retrying shortly")
+                if (result == 6 /* SCAN_FAILED_SCANNING_TOO_FREQUENTLY */) ScanStartBudget.freeze()
+                candidate.cancel()
+                scheduleRetry()
+                return
             }
 
+            pendingIntent = candidate
             Log.d(TAG, "Bluetooth Scan Broadcast registered")
 
         } catch (e: Exception) {
+            // No lying state on an exception mid-setup: the stack did NOT accept a scan.
+            pendingIntent = null
             Log.e(TAG, "Failed to setup background scanning: ${e.message}")
             io.bearound.sdk.telemetry.ErrorReporter.report(e, "BackgroundScanManager.enableBluetoothScanBroadcast")
         }
@@ -170,15 +191,16 @@ class BackgroundScanManager(private val context: Context) {
 
     /** Single-flight delayed retry for a budget-deferred (or quota-failed) registration. */
     private fun scheduleRetry(delayMs: Long = 35_000L) {
-        if (retryScheduled) return
-        retryScheduled = true
-        retryHandler.postDelayed({
-            retryScheduled = false
-            if (pendingIntent == null) {
+        if (pendingRetry != null) return
+        val retry = Runnable {
+            pendingRetry = null
+            if (desiredEnabled && pendingIntent == null) {
                 Log.d(TAG, "Retrying deferred PendingIntent scan registration")
                 enableBackgroundScanning()
             }
-        }, delayMs)
+        }
+        pendingRetry = retry
+        retryHandler.postDelayed(retry, delayMs)
     }
 
     /**

--- a/sdk/src/main/java/io/bearound/sdk/background/BackgroundScheduler.kt
+++ b/sdk/src/main/java/io/bearound/sdk/background/BackgroundScheduler.kt
@@ -7,11 +7,12 @@ import android.content.Context
 import android.content.Intent
 import android.os.Build
 import android.util.Log
-import androidx.work.Constraints
 import androidx.work.ExistingPeriodicWorkPolicy
-import androidx.work.NetworkType
 import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
+import io.bearound.sdk.models.PeriodicReconciliationDefaults
+import io.bearound.sdk.models.SDKConfiguration
+import io.bearound.sdk.utilities.SDKConfigStorage
 import java.util.concurrent.TimeUnit
 
 /**
@@ -28,8 +29,7 @@ class BackgroundScheduler private constructor(private val context: Context) {
     companion object {
         private const val TAG = "BeAroundSDK-Scheduler"
         
-        // WorkManager
-        private const val WORK_INTERVAL_MINUTES = 15L
+        // WorkManager — interval now comes from the persisted SDKConfiguration
         private const val WORK_FLEX_MINUTES = 5L
         
         // AlarmManager
@@ -79,39 +79,63 @@ class BackgroundScheduler private constructor(private val context: Context) {
     // =========================================================================
     
     /**
-     * Schedule periodic sync using WorkManager
-     * Runs every 15 minutes (minimum interval allowed)
-     * System will optimize timing based on battery and network conditions
+     * Schedules the periodic reconciliation as UNIQUE periodic work using the
+     * configured interval (default 20 min; floor = WorkManager's 15-min minimum).
+     *
+     * `ExistingPeriodicWorkPolicy.UPDATE` swaps the spec in place: repeated calls
+     * never accumulate requests, an unchanged interval is effectively a no-op, and a
+     * running worker is never interrupted. The system decides actual timing — this
+     * is best effort by design (Doze, battery optimizations, OEM policies).
+     *
+     * NO network constraint on purpose: the worker must be able to run its collection
+     * window and PERSIST results offline; the sync step inside it degrades gracefully
+     * without connectivity (data stays in the outbox for the next attempt).
      */
     fun schedulePeriodicSync() {
-        Log.d(TAG, "Scheduling periodic sync with WorkManager")
-        
-        val constraints = Constraints.Builder()
-            .setRequiredNetworkType(NetworkType.CONNECTED)
-            .build()
-        
+        val config = SDKConfigStorage.loadConfiguration(context)
+        if (config != null && !config.periodicReconciliationEnabled) {
+            Log.i(TAG, "periodic_work_cancelled reason=FEATURE_DISABLED")
+            workManager.cancelUniqueWork(BeaconSyncWorker.WORK_NAME)
+            return
+        }
+
+        val intervalMillis = config?.periodicReconciliationIntervalMillis
+            ?: PeriodicReconciliationDefaults.DEFAULT_INTERVAL_MILLIS
+
         val syncRequest = PeriodicWorkRequestBuilder<BeaconSyncWorker>(
-            WORK_INTERVAL_MINUTES, TimeUnit.MINUTES,
+            intervalMillis, TimeUnit.MILLISECONDS,
             WORK_FLEX_MINUTES, TimeUnit.MINUTES
         )
-            .setConstraints(constraints)
             .addTag("bearound_sync")
             .build()
-        
+
         workManager.enqueueUniquePeriodicWork(
             BeaconSyncWorker.WORK_NAME,
             ExistingPeriodicWorkPolicy.UPDATE,
             syncRequest
         )
-        
-        Log.d(TAG, "WorkManager periodic sync scheduled")
+
+        Log.i(TAG, "periodic_work_scheduled intervalMs=$intervalMillis (earliest bound only — execution at Android's discretion)")
     }
-    
+
+    /**
+     * Applies a (re)configuration to the periodic reconciliation: enabled → schedule
+     * or update the unique work with the configured interval; disabled → cancel the
+     * pending periodic work. Never touches a worker that is already executing.
+     */
+    fun refreshPeriodicReconciliation(config: SDKConfiguration) {
+        if (config.periodicReconciliationEnabled) {
+            schedulePeriodicSync()
+        } else {
+            cancelPeriodicSync()
+        }
+    }
+
     /**
      * Cancel periodic sync
      */
     fun cancelPeriodicSync() {
-        Log.d(TAG, "Cancelling WorkManager periodic sync")
+        Log.i(TAG, "periodic_work_cancelled reason=REQUESTED")
         workManager.cancelUniqueWork(BeaconSyncWorker.WORK_NAME)
     }
     

--- a/sdk/src/main/java/io/bearound/sdk/background/BackgroundScheduler.kt
+++ b/sdk/src/main/java/io/bearound/sdk/background/BackgroundScheduler.kt
@@ -47,6 +47,16 @@ class BackgroundScheduler private constructor(private val context: Context) {
                 }
             }
         }
+
+        /**
+         * Drops the singleton so the next getInstance() rebinds to a fresh context.
+         * Robolectric gives every test its own Application (and test WorkManager);
+         * without this the lazy WorkManager handle keeps pointing at the previous
+         * test's orphaned instance. Same test-only pattern as RegisterStore.
+         */
+        internal fun _resetForTesting() {
+            synchronized(this) { instance = null }
+        }
     }
     
     private val workManager: WorkManager by lazy { WorkManager.getInstance(context) }

--- a/sdk/src/main/java/io/bearound/sdk/background/BeaconScanService.kt
+++ b/sdk/src/main/java/io/bearound/sdk/background/BeaconScanService.kt
@@ -90,21 +90,73 @@ class BeaconScanService : Service() {
 
         fun updateNotification(context: Context, title: String, text: String) {
             if (!isRunning) return
-            val intent = Intent(context, BeaconScanService::class.java).apply {
-                putExtra(EXTRA_TITLE, title)
-                putExtra(EXTRA_TEXT, text)
-                putExtra(EXTRA_UPDATE_ONLY, true)
-            }
+            // The service is ALREADY foreground — a notification refresh only needs
+            // NotificationManager.notify. The old path re-delivered an intent through
+            // startForegroundService, a heavier mechanism subject to FGS-start policy.
             try {
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                    context.startForegroundService(intent)
-                } else {
-                    context.startService(intent)
-                }
+                val cfg = io.bearound.sdk.utilities.SDKConfigStorage.loadForegroundScanConfig(context)
+                val notification = buildNotification(
+                    context,
+                    title.ifEmpty { resolveAppName(context) },
+                    text,
+                    cfg?.notificationIcon,
+                    cfg?.notificationChannelId,
+                    cfg?.notificationChannelName ?: "Region monitoring service"
+                )
+                context.getSystemService(NotificationManager::class.java)
+                    .notify(NOTIFICATION_ID, notification)
             } catch (e: Exception) {
-                // Mesma proteção do start(): não crashar se o SO recusar (re)iniciar o FGS
-                // de background (ForegroundServiceStartNotAllowed / SecurityException).
                 Log.w(TAG, "Could not update foreground service notification — skipping", e)
+            }
+        }
+
+        private fun resolveAppName(context: Context): String {
+            return try {
+                context.applicationInfo.loadLabel(context.packageManager).toString()
+            } catch (_: Exception) {
+                "Bearound"
+            }
+        }
+
+        private fun buildNotification(
+            context: Context,
+            title: String,
+            text: String,
+            icon: Int?,
+            channelId: String?,
+            channelName: String
+        ): Notification {
+            val resolvedChannelId = channelId ?: DEFAULT_CHANNEL_ID
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                val channel = NotificationChannel(
+                    resolvedChannelId,
+                    channelName,
+                    NotificationManager.IMPORTANCE_LOW
+                ).apply {
+                    setShowBadge(false)
+                }
+                val nm = context.getSystemService(NotificationManager::class.java)
+                nm.createNotificationChannel(channel)
+            }
+
+            val resolvedIcon = icon ?: android.R.drawable.stat_sys_data_bluetooth
+
+            return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                Notification.Builder(context, resolvedChannelId)
+                    .setContentTitle(title)
+                    .setContentText(text)
+                    .setSmallIcon(resolvedIcon)
+                    .setOngoing(true)
+                    .build()
+            } else {
+                @Suppress("DEPRECATION")
+                Notification.Builder(context)
+                    .setContentTitle(title)
+                    .setContentText(text)
+                    .setSmallIcon(resolvedIcon)
+                    .setOngoing(true)
+                    .build()
             }
         }
 
@@ -113,12 +165,7 @@ class BeaconScanService : Service() {
         private const val EXTRA_ICON = "icon"
         private const val EXTRA_CHANNEL_ID = "channel_id"
         private const val EXTRA_CHANNEL_NAME = "channel_name"
-        private const val EXTRA_UPDATE_ONLY = "update_only"
     }
-
-    private var currentIcon: Int? = null
-    private var currentChannelId: String? = null
-    private var currentChannelName: String = "Region monitoring service"
 
     override fun onCreate() {
         super.onCreate()
@@ -127,28 +174,32 @@ class BeaconScanService : Service() {
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-        val rawTitle = intent?.getStringExtra(EXTRA_TITLE) ?: ""
-        val title = rawTitle.ifEmpty { resolveAppName() }
-        val text = intent?.getStringExtra(EXTRA_TEXT) ?: "Scanning for nearby content"
-        val isUpdateOnly = intent?.getBooleanExtra(EXTRA_UPDATE_ONLY, false) ?: false
-
-        if (isUpdateOnly) {
-            val nm = getSystemService(NotificationManager::class.java)
-            val notification = buildNotification(title, text, currentIcon, currentChannelId, currentChannelName)
-            nm.notify(NOTIFICATION_ID, notification)
-            Log.d(TAG, "Notification updated: $title — $text")
-            return START_STICKY
+        // START_STICKY revive: the system recreates the service with intent == null,
+        // which used to drop the host's custom title/icon/channel (in-memory only) and
+        // fall back to defaults. Reload the persisted ForegroundScanConfig instead.
+        val persistedConfig = if (intent == null) {
+            io.bearound.sdk.utilities.SDKConfigStorage.loadForegroundScanConfig(this)
+        } else {
+            null
         }
 
-        val icon = intent?.getIntExtra(EXTRA_ICON, 0)?.takeIf { it != 0 }
+        val rawTitle = intent?.getStringExtra(EXTRA_TITLE)
+            ?: persistedConfig?.notificationTitle
+            ?: ""
+        val title = rawTitle.ifEmpty { resolveAppName(this) }
+        val text = intent?.getStringExtra(EXTRA_TEXT)
+            ?: persistedConfig?.notificationText
+            ?: "Scanning for nearby content"
+
+        val icon = (intent?.getIntExtra(EXTRA_ICON, 0)?.takeIf { it != 0 })
+            ?: persistedConfig?.notificationIcon
         val channelId = intent?.getStringExtra(EXTRA_CHANNEL_ID)
-        val channelName = intent?.getStringExtra(EXTRA_CHANNEL_NAME) ?: "Region monitoring service"
+            ?: persistedConfig?.notificationChannelId
+        val channelName = intent?.getStringExtra(EXTRA_CHANNEL_NAME)
+            ?: persistedConfig?.notificationChannelName
+            ?: "Region monitoring service"
 
-        currentIcon = icon
-        currentChannelId = channelId
-        currentChannelName = channelName
-
-        val notification = buildNotification(title, text, icon, channelId, channelName)
+        val notification = buildNotification(this, title, text, icon, channelId, channelName)
 
         // Defesa em profundidade: mesmo que o serviço tenha sido iniciado antes da
         // permissão ser revogada (ex.: retry do watchdog/boot), promover a foreground
@@ -183,52 +234,4 @@ class BeaconScanService : Service() {
 
     override fun onBind(intent: Intent?): IBinder? = null
 
-    private fun resolveAppName(): String {
-        return try {
-            applicationInfo.loadLabel(packageManager).toString()
-        } catch (_: Exception) {
-            "Bearound"
-        }
-    }
-
-    private fun buildNotification(
-        title: String,
-        text: String,
-        icon: Int?,
-        channelId: String?,
-        channelName: String
-    ): Notification {
-        val resolvedChannelId = channelId ?: DEFAULT_CHANNEL_ID
-
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            val channel = NotificationChannel(
-                resolvedChannelId,
-                channelName,
-                NotificationManager.IMPORTANCE_LOW
-            ).apply {
-                setShowBadge(false)
-            }
-            val nm = getSystemService(NotificationManager::class.java)
-            nm.createNotificationChannel(channel)
-        }
-
-        val resolvedIcon = icon ?: android.R.drawable.stat_sys_data_bluetooth
-
-        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            Notification.Builder(this, resolvedChannelId)
-                .setContentTitle(title)
-                .setContentText(text)
-                .setSmallIcon(resolvedIcon)
-                .setOngoing(true)
-                .build()
-        } else {
-            @Suppress("DEPRECATION")
-            Notification.Builder(this)
-                .setContentTitle(title)
-                .setContentText(text)
-                .setSmallIcon(resolvedIcon)
-                .setOngoing(true)
-                .build()
-        }
-    }
 }

--- a/sdk/src/main/java/io/bearound/sdk/background/BeaconSyncWorker.kt
+++ b/sdk/src/main/java/io/bearound/sdk/background/BeaconSyncWorker.kt
@@ -1,73 +1,147 @@
 package io.bearound.sdk.background
 
 import android.content.Context
+import android.os.Build
+import android.os.PowerManager
 import android.util.Log
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
 import io.bearound.sdk.BeAroundSDK
+import io.bearound.sdk.utilities.SDKConfigStorage
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.withContext
 
 /**
- * WorkManager Worker for periodic beacon sync
- * Runs every 15 minutes (minimum interval) to sync pending beacons
- * 
- * This provides a fallback mechanism when:
- * - Bluetooth Scan Broadcast doesn't fire (Android < 14)
- * - App was killed by system
- * - Network was unavailable during previous sync attempts
+ * Periodic beacon reconciliation (unique [androidx.work.PeriodicWorkRequest], see
+ * [BackgroundScheduler.schedulePeriodicSync]). Best effort by design: Android decides
+ * the actual timing (Doze, battery optimizations, OEM policies), and the PendingIntent
+ * scan remains the PRIMARY out-of-process detection mechanism — this worker is a
+ * complementary safety net that:
+ *
+ * 1. Self-heals the background scan registration when the host wants scanning;
+ * 2. Waits a short, configurable collection window for the CONTINUOUS scanners to
+ *    deliver (it never registers a scanner, PendingIntent, or foreground service of
+ *    its own — so there is no scan ownership to hand back when it finishes);
+ * 3. Drains pending data through the existing single-flight sync pipeline
+ *    (persist-before-send, batch ids, poison-batch quarantine all apply).
+ *
+ * Battery policy: in Battery Saver or serious/critical thermal state the collection
+ * window is skipped — at most the already-pending data is synchronized. When the host
+ * called stopScanning() the worker NEVER touches scan state and only drains leftovers.
  */
 class BeaconSyncWorker(
     context: Context,
     params: WorkerParameters
 ) : CoroutineWorker(context, params) {
-    
+
     companion object {
         private const val TAG = "BeAroundSDK-SyncWorker"
         const val WORK_NAME = "beacon_sync_work"
+
+        /** Poll cadence of the collection window (the batch scan flushes every ~2s). */
+        private const val COLLECTION_POLL_MS = 500L
     }
-    
+
+    private enum class SkipReason {
+        FEATURE_DISABLED, SDK_NOT_CONFIGURED, BATTERY_SAVER, THERMAL_RESTRICTION, HOST_STOPPED_SCANNING
+    }
+
     override suspend fun doWork(): Result = withContext(Dispatchers.IO) {
-        Log.d(TAG, "BeaconSyncWorker started")
-        
+        Log.i(TAG, "periodic_worker_started attempt=$runAttemptCount")
+
         try {
             val sdk = BeAroundSDK.getInstance(applicationContext)
-            
+
             // Check if SDK is configured
             if (!sdk.isConfigured) {
                 Log.d(TAG, "SDK not configured, attempting restore")
                 sdk.attemptConfigRestore()
-                
+
                 if (!sdk.isConfigured) {
-                    Log.w(TAG, "SDK still not configured, skipping sync")
+                    logSkip(SkipReason.SDK_NOT_CONFIGURED)
                     return@withContext Result.success()
                 }
             }
-            
+
+            val config = SDKConfigStorage.loadConfiguration(applicationContext)
+            if (config?.periodicReconciliationEnabled == false) {
+                // Disabled between scheduling and execution (the unique work is also
+                // cancelled on reconfigure — this covers the race). Skipping is success.
+                logSkip(SkipReason.FEATURE_DISABLED)
+                return@withContext Result.success()
+            }
+
+            // ── Reconciliation policy ────────────────────────────────────────
+            // Host intent rules everything: after stopScanning() the worker never
+            // touches scan state — it only drains data that already exists.
+            val wantsScanning = sdk.wasScanningEnabled()
+            val powerManager = applicationContext.getSystemService(Context.POWER_SERVICE) as? PowerManager
+            val batterySaver = powerManager?.isPowerSaveMode == true
+            val thermalRestricted = Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q &&
+                (powerManager?.currentThermalStatus ?: 0) >= PowerManager.THERMAL_STATUS_SEVERE
+
+            val mayCollect = wantsScanning && !batterySaver && !thermalRestricted
+            if (!mayCollect) {
+                when {
+                    !wantsScanning -> logSkip(SkipReason.HOST_STOPPED_SCANNING)
+                    batterySaver -> logSkip(SkipReason.BATTERY_SAVER)
+                    else -> logSkip(SkipReason.THERMAL_RESTRICTION)
+                }
+            } else {
+                // Self-heal: the PendingIntent client (the only out-of-process detector)
+                // can be silently dead with the local flag still true. One budget-guarded
+                // re-registration per run — same cheap heal the 15-min watchdog performs.
+                sdk.refreshBackgroundScanRegistration()
+
+                // Collection window: WAIT (never scan ourselves) for the continuous
+                // scanners to deliver, bounded by the configured window. Data already
+                // present short-circuits immediately (recent detection → no wait).
+                val windowMs = config?.periodicScanDurationMillis
+                    ?: io.bearound.sdk.models.PeriodicReconciliationDefaults.DEFAULT_SCAN_DURATION_MILLIS
+                val windowStart = System.currentTimeMillis()
+                var waited = 0L
+                while (!sdk.hasPendingBeacons() &&
+                    System.currentTimeMillis() - windowStart < windowMs
+                ) {
+                    ensureActive() // respond to WorkManager cancellation promptly
+                    delay(COLLECTION_POLL_MS)
+                    waited += COLLECTION_POLL_MS
+                }
+                if (waited > 0) {
+                    Log.i(TAG, "periodic_scan_duration waitedMs=$waited windowMs=$windowMs dataFound=${sdk.hasPendingBeacons()}")
+                }
+            }
+
+            ensureActive()
+
             // Check if there are pending beacons or failed batches
             val hasPendingData = sdk.hasPendingBeacons()
 
             if (hasPendingData) {
-                Log.d(TAG, "Syncing pending beacons...")
+                Log.i(TAG, "periodic_sync_requested")
                 // AWAIT the upload: returning before it finishes released the
                 // WorkManager window (and its wakelock) with the POST in flight.
+                // Offline: the sync fails, data STAYS persisted (persist-before-send),
+                // and retry/backoff owns the redelivery — nothing is lost.
                 val ok = sdk.performBackgroundSyncAwait()
-                Log.d(TAG, "Background sync completed (success=$ok)")
+                Log.i(TAG, "periodic_sync_completed success=$ok")
                 if (!ok) {
                     BackgroundScheduler.getInstance(applicationContext).scheduleWatchdogAlarm()
                     return@withContext if (runAttemptCount < 3) Result.retry() else Result.failure()
                 }
             } else {
-                Log.d(TAG, "No pending beacons to sync")
+                Log.i(TAG, "periodic_worker_completed result=NOTHING_TO_DO")
             }
 
             // Reschedule watchdog alarm
             BackgroundScheduler.getInstance(applicationContext).scheduleWatchdogAlarm()
 
             Result.success()
-            
+
         } catch (e: Exception) {
-            Log.e(TAG, "Error in BeaconSyncWorker: ${e.message}")
+            Log.e(TAG, "periodic_worker_failed: ${e.message}")
             io.bearound.sdk.telemetry.ErrorReporter.report(e, "BeaconSyncWorker.doWork")
 
             // Retry if this is a transient failure
@@ -77,5 +151,9 @@ class BeaconSyncWorker(
                 Result.failure()
             }
         }
+    }
+
+    private fun logSkip(reason: SkipReason) {
+        Log.i(TAG, "periodic_worker_skipped reason=$reason")
     }
 }

--- a/sdk/src/main/java/io/bearound/sdk/background/BluetoothScanReceiver.kt
+++ b/sdk/src/main/java/io/bearound/sdk/background/BluetoothScanReceiver.kt
@@ -47,6 +47,26 @@ class BluetoothScanReceiver : BroadcastReceiver() {
                 }
             }
 
+            // The PendingIntent pipeline reports failures through EXTRA_ERROR_CODE (e.g.
+            // the stack tore the registration down, or scan-start throttling kicked in).
+            // Ignoring it kept the "background scan registered" state alive on a client
+            // the OS had already rejected — the out-of-region detector was silently dead.
+            val errorCode = intent.getIntExtra(BluetoothLeScanner.EXTRA_ERROR_CODE, 0)
+            if (errorCode != 0) {
+                Log.w(TAG, "PendingIntent scan delivered error code $errorCode")
+                if (errorCode == 6 /* SCAN_FAILED_SCANNING_TOO_FREQUENTLY, API 30+ */) {
+                    // Freeze the budget and let the 15-min watchdog re-register once the
+                    // recovery window passes — an immediate re-start would be one more
+                    // start against the very quota that just tripped.
+                    io.bearound.sdk.utilities.ScanStartBudget.freeze()
+                } else {
+                    // Other failures (registration dropped, internal error): one
+                    // budget-guarded re-registration now.
+                    sdk.refreshBackgroundScanRegistration()
+                }
+                return
+            }
+
             val scanResults = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
                 intent.getParcelableArrayListExtra(
                     BluetoothLeScanner.EXTRA_LIST_SCAN_RESULT,
@@ -86,7 +106,6 @@ class BluetoothScanReceiver : BroadcastReceiver() {
     }
 
     private fun hasRequiredPermissions(context: Context): Boolean {
-        // Two "eyes": Location and Bluetooth. Accept results if AT LEAST ONE is granted.
         val hasLocation =
             ContextCompat.checkSelfPermission(
                 context,
@@ -97,16 +116,22 @@ class BluetoothScanReceiver : BroadcastReceiver() {
                 Manifest.permission.ACCESS_COARSE_LOCATION
             ) == PackageManager.PERMISSION_GRANTED
 
-        val hasBluetoothScan = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            ContextCompat.checkSelfPermission(
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            // Android 12+: Bluetooth-only detection via BLUETOOTH_SCAN + neverForLocation
+            // (see the library manifest). Location additionally satisfies OEMs that still
+            // gate on it — either eye is enough.
+            val hasBluetoothScan = ContextCompat.checkSelfPermission(
                 context,
                 Manifest.permission.BLUETOOTH_SCAN
             ) == PackageManager.PERMISSION_GRANTED
+            hasLocation || hasBluetoothScan
         } else {
-            // Pre-Android-12: BLUETOOTH/BLUETOOTH_ADMIN are install-time normal permissions.
-            true
+            // Pre-Android-12: BLE scan results are location-gated by the platform — the
+            // legacy BLUETOOTH/BLUETOOTH_ADMIN install-time permissions do NOT unlock
+            // them. The old `hasLocation || true` accepted work here that could never
+            // produce results, keeping "background scan registered" state alive on a
+            // pipeline the OS had silently zeroed.
+            hasLocation
         }
-
-        return hasLocation || hasBluetoothScan
     }
 }

--- a/sdk/src/main/java/io/bearound/sdk/background/ScanWatchdogReceiver.kt
+++ b/sdk/src/main/java/io/bearound/sdk/background/ScanWatchdogReceiver.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.Intent
 import android.util.Log
 import io.bearound.sdk.BeAroundSDK
+import io.bearound.sdk.background.ImmediateSyncWorker
 
 /**
  * AlarmManager BroadcastReceiver that acts as a watchdog
@@ -69,14 +70,22 @@ class ScanWatchdogReceiver : BroadcastReceiver() {
                 sdk.refreshBackgroundScanRegistration()
             }
 
-            // Sync any pending beacons
+            // Sync any pending beacons. The receiver has no execution window of its own
+            // (the process is freezable the moment onReceive returns, and the old direct
+            // performBackgroundSync() was fire-and-forget into that void) — hand the
+            // upload to the expedited worker, which owns a WorkManager window + wakelock.
             if (sdk.hasPendingBeacons()) {
-                Log.d(TAG, "Watchdog: Syncing pending beacons")
-                sdk.performBackgroundSync()
+                Log.d(TAG, "Watchdog: pending beacons — enqueuing ImmediateSyncWorker")
+                ImmediateSyncWorker.enqueue(context.applicationContext)
             }
-            
-            // Reschedule next watchdog alarm
-            BackgroundScheduler.getInstance(context.applicationContext).scheduleWatchdogAlarm()
+
+            // Reschedule ONLY while scanning is still wanted: after stopScanning() the
+            // old unconditional reschedule kept the alarm waking the process forever.
+            if (shouldBeScanning) {
+                BackgroundScheduler.getInstance(context.applicationContext).scheduleWatchdogAlarm()
+            } else {
+                Log.d(TAG, "Watchdog: scanning disabled — not rescheduling")
+            }
             
         } catch (e: Exception) {
             Log.e(TAG, "Watchdog error: ${e.message}")

--- a/sdk/src/main/java/io/bearound/sdk/models/SDKConfiguration.kt
+++ b/sdk/src/main/java/io/bearound/sdk/models/SDKConfiguration.kt
@@ -12,27 +12,10 @@ data class SDKConfiguration(
 ) {
     val apiBaseURL: String = "https://ingest.bearound.io"
 
-    /** Scan duration is always 10s for all precision modes */
-    val precisionScanDuration: Long = 10_000L
-
-    /** Pause duration between scans: HIGH=0, MEDIUM=10s, LOW=50s */
-    val precisionPauseDuration: Long
-        get() = when (scanPrecision) {
-            ScanPrecision.HIGH -> 0L
-            ScanPrecision.MEDIUM -> 10_000L
-            ScanPrecision.LOW -> 50_000L
-        }
-
-    /** Number of scan+pause cycles per window: HIGH=0 (continuous), MEDIUM=3, LOW=1 */
-    val precisionCycleCount: Int
-        get() = when (scanPrecision) {
-            ScanPrecision.HIGH -> 0
-            ScanPrecision.MEDIUM -> 3
-            ScanPrecision.LOW -> 1
-        }
-
-    /** Cycle interval (window duration) is always 60s */
-    val precisionCycleInterval: Long = 60_000L
+    // NOTE: the old precisionScanDuration/PauseDuration/CycleCount/CycleInterval props
+    // described a manual scan/pause duty cycle the SDK no longer runs — scanning is
+    // continuous and the OS handles duty-cycling; precision now only drives the scan
+    // mode (see BeaconManager.rangingScanMode) and the sync cadence below.
 
     /** Sync interval: HIGH=15s, MEDIUM/LOW=60s */
     val syncInterval: Long

--- a/sdk/src/main/java/io/bearound/sdk/models/SDKConfiguration.kt
+++ b/sdk/src/main/java/io/bearound/sdk/models/SDKConfiguration.kt
@@ -1,5 +1,68 @@
 package io.bearound.sdk.models
 
+import android.util.Log
+
+/**
+ * Defaults and safety bounds for the periodic background reconciliation
+ * ([androidx.work.PeriodicWorkRequest] layer). Public so hosts can reference the
+ * same constants.
+ *
+ * The bounds are PRODUCT guard rails, not just input validation:
+ * - **Interval floor (15 min)**: WorkManager's own hard minimum for periodic work
+ *   ([androidx.work.PeriodicWorkRequest.MIN_PERIODIC_INTERVAL_MILLIS]). Note that
+ *   WorkManager silently raises smaller values to 15 min on its own — the SDK clamps
+ *   WITH a loud warning instead of letting that happen invisibly.
+ * - **Interval ceiling (24 h)**: past this the layer is effectively off — disable it
+ *   explicitly ([SDKConfiguration.periodicReconciliationEnabled]) instead.
+ * - **Scan window (3–30 s)**: bounded so a misconfigured window can neither miss the
+ *   advertising cadence (< 3 s) nor camp on the radio (> 30 s).
+ */
+object PeriodicReconciliationDefaults {
+    private const val TAG = "BeAroundSDK-Config"
+
+    const val DEFAULT_INTERVAL_MILLIS: Long = 20L * 60L * 1000L
+    /** WorkManager's hard minimum for periodic work. */
+    const val MINIMUM_INTERVAL_MILLIS: Long = 15L * 60L * 1000L
+    const val MAXIMUM_INTERVAL_MILLIS: Long = 24L * 60L * 60L * 1000L
+    const val DEFAULT_SCAN_DURATION_MILLIS: Long = 12L * 1000L
+    const val MINIMUM_SCAN_DURATION_MILLIS: Long = 3L * 1000L
+    const val MAXIMUM_SCAN_DURATION_MILLIS: Long = 30L * 1000L
+
+    /**
+     * Sanitizes a host-provided interval: non-positive values fall back to the default;
+     * out-of-range values are clamped into [MINIMUM_INTERVAL_MILLIS,
+     * MAXIMUM_INTERVAL_MILLIS]. Every adjustment logs an ERROR-level warning — never a
+     * silent change, never a crash (never-crash-the-host doctrine).
+     */
+    fun sanitizedInterval(value: Long): Long {
+        if (value <= 0L) {
+            Log.e(TAG, "⚠️ periodicReconciliationIntervalMillis ($value) is invalid — using the ${DEFAULT_INTERVAL_MILLIS / 60000} min default. Accepted range: ${MINIMUM_INTERVAL_MILLIS / 60000} min – ${MAXIMUM_INTERVAL_MILLIS / 3600000} h.")
+            return DEFAULT_INTERVAL_MILLIS
+        }
+        if (value < MINIMUM_INTERVAL_MILLIS) {
+            Log.e(TAG, "⚠️ periodicReconciliationIntervalMillis ${value}ms is below WorkManager's 15-min minimum for periodic work — CLAMPED to 15 min. (WorkManager would silently raise it anyway; the SDK warns instead.)")
+            return MINIMUM_INTERVAL_MILLIS
+        }
+        if (value > MAXIMUM_INTERVAL_MILLIS) {
+            Log.e(TAG, "⚠️ periodicReconciliationIntervalMillis ${value}ms is above the 24h ceiling — CLAMPED. If you want the layer off, set periodicReconciliationEnabled = false instead.")
+            return MAXIMUM_INTERVAL_MILLIS
+        }
+        return value
+    }
+
+    /** Sanitizes the scan-window duration into [MINIMUM_SCAN_DURATION_MILLIS, MAXIMUM_SCAN_DURATION_MILLIS]. */
+    fun sanitizedScanDuration(value: Long): Long {
+        if (value <= 0L) {
+            Log.e(TAG, "⚠️ periodicScanDurationMillis ($value) is invalid — using the ${DEFAULT_SCAN_DURATION_MILLIS / 1000}s default. Accepted range: ${MINIMUM_SCAN_DURATION_MILLIS / 1000}–${MAXIMUM_SCAN_DURATION_MILLIS / 1000}s.")
+            return DEFAULT_SCAN_DURATION_MILLIS
+        }
+        if (value < MINIMUM_SCAN_DURATION_MILLIS || value > MAXIMUM_SCAN_DURATION_MILLIS) {
+            Log.e(TAG, "⚠️ periodicScanDurationMillis ${value}ms is outside the ${MINIMUM_SCAN_DURATION_MILLIS / 1000}–${MAXIMUM_SCAN_DURATION_MILLIS / 1000}s range — CLAMPED.")
+        }
+        return value.coerceIn(MINIMUM_SCAN_DURATION_MILLIS, MAXIMUM_SCAN_DURATION_MILLIS)
+    }
+}
+
 /**
  * Configuration for the BeAround SDK
  */
@@ -8,7 +71,33 @@ data class SDKConfiguration(
     val appId: String,
     val scanPrecision: ScanPrecision = ScanPrecision.MEDIUM,
     val maxQueuedPayloads: MaxQueuedPayloads = MaxQueuedPayloads.MEDIUM,
-    val technology: String = "android-native"
+    val technology: String = "android-native",
+    /**
+     * Enables the periodic background reconciliation (WorkManager layer).
+     *
+     * A best-effort safety net: a [androidx.work.PeriodicWorkRequest] that periodically
+     * checks scan health, waits a short collection window when useful, and syncs pending
+     * data through the existing pipeline. Complementary to the PendingIntent scan —
+     * never a replacement. Subject to Doze/battery optimizations and OEM policies;
+     * force-stop suspends it until the app is launched again.
+     */
+    val periodicReconciliationEnabled: Boolean = true,
+    /**
+     * Minimum interval requested between eligible executions — a floor, never a
+     * guaranteed cadence (Android may run the worker much later).
+     *
+     * Accepted range: **15 minutes (WorkManager's hard minimum) … 24 hours**.
+     * Out-of-range values are clamped with an ERROR-level log; non-positive values
+     * fall back to the 20-minute default. Sanitize via
+     * [PeriodicReconciliationDefaults.sanitizedInterval] before constructing directly.
+     */
+    val periodicReconciliationIntervalMillis: Long = PeriodicReconciliationDefaults.DEFAULT_INTERVAL_MILLIS,
+    /**
+     * Ceiling of the temporary collection window inside the worker, clamped to
+     * **3–30 seconds**. Only used while waiting for the continuous scanners to deliver;
+     * the worker never registers scanners of its own.
+     */
+    val periodicScanDurationMillis: Long = PeriodicReconciliationDefaults.DEFAULT_SCAN_DURATION_MILLIS
 ) {
     val apiBaseURL: String = "https://ingest.bearound.io"
 

--- a/sdk/src/main/java/io/bearound/sdk/telemetry/ErrorReporter.kt
+++ b/sdk/src/main/java/io/bearound/sdk/telemetry/ErrorReporter.kt
@@ -25,6 +25,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import org.json.JSONObject
+import java.io.File
 import java.io.PrintWriter
 import java.io.StringWriter
 import java.net.HttpURLConnection
@@ -176,6 +177,11 @@ object ErrorReporter {
                     }
                 }
             }
+
+            // Prepare the crash-envelope dir OUTSIDE the crash path, then ship anything
+            // a previous run's crash left behind.
+            File(context.applicationContext.filesDir, CRASH_ENVELOPE_DIR).mkdirs()
+            drainPendingCrashEnvelopes(context.applicationContext, businessToken)
         } catch (t: Throwable) {
             safeLog { Log.w(TAG, "Error telemetry install failed: ${t.message}") }
         }
@@ -229,12 +235,80 @@ object ErrorReporter {
     ) : Thread.UncaughtExceptionHandler {
         override fun uncaughtException(thread: Thread, throwable: Throwable) {
             try {
-                // report() applies the origin filter itself (single choke point).
-                report(throwable, "uncaught-handler")
+                // The old path called report(), which launched the delivery on a
+                // coroutine scope — the process dies in the chained handler below long
+                // before that coroutine runs, so crash reports were silently lost.
+                // Persist a ready-to-send envelope to disk instead (one atomic file
+                // write, ~ms) and deliver it on the NEXT launch (see install()).
+                persistCrashEnvelope(throwable)
             } catch (_: Throwable) {
                 // Never let telemetry interfere with the host's crash handling.
             } finally {
                 previous?.uncaughtException(thread, throwable)
+            }
+        }
+    }
+
+    /** Directory for crash envelopes; created in install() so the crash path only writes. */
+    private const val CRASH_ENVELOPE_DIR = "bearound_crash_envelopes"
+    private const val MAX_PENDING_CRASH_ENVELOPES = 5
+
+    /**
+     * Builds the full payload (synchronous + cheap on Android: Build.*, JSONObject,
+     * permission snapshots — no network, no locks) and writes it atomically. Origin
+     * filter still applies — host crashes are never captured.
+     */
+    private fun persistCrashEnvelope(throwable: Throwable) {
+        if (!enabled) return
+        val ctx = appContext ?: return
+        if (!isFromSdk(throwable)) return
+
+        val stack = stackTraceOf(throwable)
+        val body = buildPayload(throwable, "uncaught-handler", stack, ctx).toString()
+
+        val dir = File(ctx.filesDir, CRASH_ENVELOPE_DIR)
+        if (!dir.isDirectory) return // install() didn't prepare it — skip, never mkdir here
+
+        val name = "crash-${System.currentTimeMillis()}.json"
+        val tmp = File(dir, "$name.tmp")
+        tmp.writeText(body)
+        if (!tmp.renameTo(File(dir, name))) tmp.delete()
+    }
+
+    /**
+     * Delivers envelopes a previous run's crash handler left behind, then removes them.
+     * Any transport-level failure keeps the file for the next launch; a served response
+     * (any status) counts as delivered — telemetry is fire-and-forget.
+     */
+    private fun drainPendingCrashEnvelopes(ctx: Context, token: String) {
+        scope.launch {
+            try {
+                val dir = File(ctx.filesDir, CRASH_ENVELOPE_DIR)
+                if (!dir.isDirectory) return@launch
+                val envelopes = dir.listFiles()
+                    ?.filter { it.name.startsWith("crash-") && it.name.endsWith(".json") }
+                    ?.sortedBy { it.name }
+                    ?: return@launch
+
+                // Cap: newest N survive, surplus is dropped outright.
+                envelopes.dropLast(MAX_PENDING_CRASH_ENVELOPES).forEach { it.delete() }
+
+                for (file in envelopes.takeLast(MAX_PENDING_CRASH_ENVELOPES)) {
+                    val body = try {
+                        file.readText()
+                    } catch (_: Throwable) {
+                        file.delete(); continue
+                    }
+                    val delivered = try {
+                        transport(body, token)
+                        true
+                    } catch (_: Throwable) {
+                        false
+                    }
+                    if (delivered) file.delete()
+                }
+            } catch (t: Throwable) {
+                safeLog { Log.w(TAG, "Crash envelope drain failed: ${t.message}") }
             }
         }
     }

--- a/sdk/src/main/java/io/bearound/sdk/utilities/DeviceInfoCollector.kt
+++ b/sdk/src/main/java/io/bearound/sdk/utilities/DeviceInfoCollector.kt
@@ -25,9 +25,17 @@ import java.util.TimeZone
  * Collects comprehensive device information for API requests
  */
 class DeviceInfoCollector(
-    private val context: Context,
-    private val isColdStart: Boolean = true
+    private val context: Context
 ) {
+    companion object {
+        /**
+         * True only for the FIRST payload each process builds. The old constructor flag
+         * was hardcoded `true` for the singleton's whole life, so every sync reported
+         * coldStart=true and the field carried no signal.
+         */
+        private val firstPayloadOfProcess = java.util.concurrent.atomic.AtomicBoolean(true)
+    }
+
     private val appStartTime = System.currentTimeMillis()
 
     fun collectDeviceInfo(
@@ -56,7 +64,7 @@ class DeviceInfoCollector(
             screenHeight = getScreenHeight(),
             appInForeground = appInForeground,
             appUptimeMs = System.currentTimeMillis() - appStartTime,
-            coldStart = isColdStart,
+            coldStart = firstPayloadOfProcess.getAndSet(false),
             lowPowerMode = isLowPowerMode(),
             locationAccuracy = getLocationAccuracy(locationPermission),
             wifiSSID = getWifiSSID(),

--- a/sdk/src/main/java/io/bearound/sdk/utilities/OfflineBatchStorage.kt
+++ b/sdk/src/main/java/io/bearound/sdk/utilities/OfflineBatchStorage.kt
@@ -368,6 +368,25 @@ class OfflineBatchStorage(private val context: Context) {
 
     /** Removes exactly these batch ids; returns how many were deleted. */
     fun removeBatches(ids: List<String>): Int = ids.count { removeBatch(it) }
+
+    /**
+     * Takes a backend-REJECTED batch out of the send queue (renamed to .rejected — kept
+     * for diagnosis, swept by the 7-day expiry). Without this, one poison batch at the
+     * head of the FIFO blocked every batch behind it until expiry.
+     */
+    fun quarantineBatch(id: String): Boolean = lock.withLock {
+        try {
+            val file = storageDirectory.listFiles()
+                ?.firstOrNull { it.extension == "json" && it.nameWithoutExtension.endsWith(id) }
+                ?: return@withLock false
+            val moved = file.renameTo(File(storageDirectory, "${file.nameWithoutExtension}.rejected"))
+            if (moved) Log.w(TAG, "Quarantined rejected batch: ${file.name}")
+            moved
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to quarantine batch $id: ${e.message}", e)
+            false
+        }
+    }
     
     /**
      * Clears all stored batches
@@ -400,10 +419,14 @@ class OfflineBatchStorage(private val context: Context) {
     
     private fun cleanupExpiredBatches() {
         try {
-            // .json = pending; .corrupt = quarantined; .tmp = interrupted atomic write.
-            // All carry the timestamp in the filename and all expire on the same 7-day clock.
+            // .json = pending; .corrupt = unreadable; .rejected = backend-refused;
+            // .tmp = interrupted atomic write. All carry the timestamp in the filename
+            // and all expire on the same 7-day clock.
             val files = storageDirectory.listFiles()
-                ?.filter { it.extension == "json" || it.extension == "corrupt" || it.extension == "tmp" }
+                ?.filter {
+                    it.extension == "json" || it.extension == "corrupt" ||
+                        it.extension == "rejected" || it.extension == "tmp"
+                }
                 ?: return
             
             val now = System.currentTimeMillis()

--- a/sdk/src/main/java/io/bearound/sdk/utilities/OfflineBatchStorage.kt
+++ b/sdk/src/main/java/io/bearound/sdk/utilities/OfflineBatchStorage.kt
@@ -43,7 +43,21 @@ class OfflineBatchStorage(private val context: Context) {
     private data class StoredBatch(
         @SerializedName("id") val id: String,
         @SerializedName("timestamp") val timestamp: Long,
+        // Fingerprint of the business token the batch was collected under. Batches from
+        // a DIFFERENT tenant are never sent with the current credential (multi-tenant
+        // isolation); null = written before this field existed → treated as current.
+        @SerializedName("tenantId") val tenantId: String? = null,
         @SerializedName("beacons") val beacons: List<StoredBeacon>
+    )
+
+    /**
+     * Public read model: the batch id travels with the beacons so callers remove EXACTLY
+     * the batches a successful upload represents — never "the N oldest at removal time",
+     * which drifts when saves/cleanup run between load and remove.
+     */
+    data class StoredBatchRecord(
+        val id: String,
+        val beacons: List<Beacon>
     )
     
     private data class StoredBeacon(
@@ -177,9 +191,17 @@ class OfflineBatchStorage(private val context: Context) {
         .create()
     
     private val lock = ReentrantLock()
-    
+
     /** Maximum number of batches to store (default from MaxQueuedPayloads.medium) */
     var maxBatchCount: Int = MaxQueuedPayloads.MEDIUM.value
+
+    /**
+     * Fingerprint of the currently-configured business token (set by configure()).
+     * Reads only return batches written under this tenant (or legacy batches with no
+     * tenant recorded); foreign-tenant batches stay on disk until the 7-day expiry so
+     * data collected for client A is never delivered with client B's credential.
+     */
+    var currentTenantId: String? = null
     
     /** Storage directory */
     private val storageDirectory: File by lazy {
@@ -220,144 +242,132 @@ class OfflineBatchStorage(private val context: Context) {
     }
     
     /**
-     * Saves a batch of beacons to persistent storage
-     * @param beacons Array of beacons to store
+     * Saves a batch of beacons to persistent storage.
      * @return true if saved successfully
      */
-    fun saveBatch(beacons: List<Beacon>): Boolean {
+    fun saveBatch(beacons: List<Beacon>): Boolean = saveBatchReturningId(beacons) != null
+
+    /**
+     * Saves a batch and returns its id (persist-before-send: the caller uploads the
+     * payload AND, on success, removes exactly this id). Null when the write failed.
+     */
+    fun saveBatchReturningId(beacons: List<Beacon>): String? {
         if (beacons.isEmpty()) {
             Log.w(TAG, "Cannot save empty batch")
-            return false
+            return null
         }
-        
+
         return lock.withLock {
             try {
                 val batchId = UUID.randomUUID().toString()
                 val timestamp = System.currentTimeMillis()
-                
+
                 val storedBeacons = beacons.map { StoredBeacon.fromBeacon(it) }
                 val batch = StoredBatch(
                     id = batchId,
                     timestamp = timestamp,
+                    tenantId = currentTenantId,
                     beacons = storedBeacons
                 )
-                
+
                 // Filename format: timestamp_uuid.json for sorting
                 val filename = "${timestamp}_${batchId}.json"
-                val file = File(storageDirectory, filename)
-                
                 val json = gson.toJson(batch)
-                file.writeText(json)
-                
+
+                // Atomic write: tmp + fsync + rename (same directory = same filesystem).
+                // A process death mid-write leaves a .tmp the readers never pick up,
+                // instead of a half-written .json that would be silently dropped as
+                // corrupted on the next read.
+                val tempFile = File(storageDirectory, "$filename.tmp")
+                val finalFile = File(storageDirectory, filename)
+                tempFile.outputStream().use { output ->
+                    output.write(json.toByteArray(Charsets.UTF_8))
+                    output.flush()
+                    output.fd.sync()
+                }
+                if (!tempFile.renameTo(finalFile)) {
+                    tempFile.delete()
+                    Log.e(TAG, "Failed to rename temp batch file $filename")
+                    return@withLock null
+                }
+
                 Log.d(TAG, "Saved batch with ${beacons.size} beacons to $filename")
-                
+
                 // Enforce max batch count (remove oldest if exceeded)
                 enforceMaxBatchCount()
-                
-                true
+
+                batchId
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to save batch: ${e.message}", e)
-                false
-            }
-        }
-    }
-    
-    /**
-     * Loads the oldest batch from storage (FIFO)
-     * @return List of beacons or null if no batches available
-     */
-    fun loadOldestBatch(): List<Beacon>? {
-        return lock.withLock {
-            try {
-                val files = storageDirectory.listFiles()
-                    ?.filter { it.extension == "json" }
-                    ?.sortedBy { it.name }
-                
-                val oldestFile = files?.firstOrNull() ?: return@withLock null
-                
-                val json = oldestFile.readText()
-                val batch = gson.fromJson(json, StoredBatch::class.java)
-                
-                val beacons = batch.beacons.map { it.toBeacon() }
-                Log.d(TAG, "Loaded oldest batch with ${beacons.size} beacons from ${oldestFile.name}")
-                
-                beacons
-            } catch (e: Exception) {
-                Log.e(TAG, "Failed to load oldest batch: ${e.message}", e)
-                // Try to remove corrupted file
-                try {
-                    val files = storageDirectory.listFiles()
-                        ?.filter { it.extension == "json" }
-                        ?.sortedBy { it.name }
-                    files?.firstOrNull()?.delete()
-                } catch (cleanupError: Exception) {
-                    Log.e(TAG, "Failed to cleanup corrupted batch: ${cleanupError.message}")
-                }
                 null
             }
         }
     }
-    
+
     /**
-     * Removes the oldest batch from storage (call after successful sync)
-     * @return true if removed successfully
+     * Loads up to [count] oldest batches (FIFO) for the CURRENT tenant, with their ids.
+     * Corrupted files are quarantined (renamed to .corrupt — kept for diagnosis, swept
+     * by the 7-day expiry) instead of silently deleted.
      */
-    fun removeOldestBatch(): Boolean {
-        return lock.withLock {
-            try {
-                val files = storageDirectory.listFiles()
-                    ?.filter { it.extension == "json" }
-                    ?.sortedBy { it.name }
-                
-                val oldestFile = files?.firstOrNull() ?: return@withLock false
-                
-                val deleted = oldestFile.delete()
-                if (deleted) {
-                    Log.d(TAG, "Removed batch file: ${oldestFile.name}")
-                }
-                deleted
-            } catch (e: Exception) {
-                Log.e(TAG, "Failed to remove oldest batch: ${e.message}", e)
-                false
-            }
-        }
-    }
-    
-    /**
-     * Loads all batches from storage (for migration or debugging)
-     * @return List of beacon lists, ordered oldest first
-     */
-    fun loadAllBatches(): List<List<Beacon>> {
+    fun loadOldestRecords(count: Int = Int.MAX_VALUE): List<StoredBatchRecord> {
         return lock.withLock {
             try {
                 val files = storageDirectory.listFiles()
                     ?.filter { it.extension == "json" }
                     ?.sortedBy { it.name }
                     ?: return@withLock emptyList()
-                
-                val allBatches = mutableListOf<List<Beacon>>()
-                
+
+                val records = mutableListOf<StoredBatchRecord>()
                 for (file in files) {
+                    if (records.size >= count) break
                     try {
-                        val json = file.readText()
-                        val batch = gson.fromJson(json, StoredBatch::class.java)
-                        val beacons = batch.beacons.map { it.toBeacon() }
-                        allBatches.add(beacons)
+                        val batch = gson.fromJson(file.readText(), StoredBatch::class.java)
+                        // Tenant isolation: skip batches written under a different token.
+                        // (null tenant = legacy file → treated as current.)
+                        if (batch.tenantId != null && currentTenantId != null &&
+                            batch.tenantId != currentTenantId
+                        ) {
+                            continue
+                        }
+                        records.add(
+                            StoredBatchRecord(
+                                id = batch.id,
+                                beacons = batch.beacons.map { it.toBeacon() }
+                            )
+                        )
                     } catch (e: Exception) {
-                        Log.e(TAG, "Failed to load batch ${file.name}: ${e.message}")
-                        // Remove corrupted file
-                        file.delete()
+                        Log.e(TAG, "Corrupted batch ${file.name} — quarantining: ${e.message}")
+                        file.renameTo(File(storageDirectory, "${file.nameWithoutExtension}.corrupt"))
                     }
                 }
-                
-                Log.d(TAG, "Loaded ${allBatches.size} batches from storage")
-                allBatches
+                records
             } catch (e: Exception) {
-                Log.e(TAG, "Failed to load all batches: ${e.message}", e)
+                Log.e(TAG, "Failed to load batch records: ${e.message}", e)
                 emptyList()
             }
         }
     }
+
+    /** All pending batches for the current tenant, oldest first. */
+    fun loadAllRecords(): List<StoredBatchRecord> = loadOldestRecords()
+
+    /** Removes the batch with exactly this id. */
+    fun removeBatch(id: String): Boolean = lock.withLock {
+        try {
+            val file = storageDirectory.listFiles()
+                ?.firstOrNull { it.extension == "json" && it.nameWithoutExtension.endsWith(id) }
+                ?: return@withLock false
+            val deleted = file.delete()
+            if (deleted) Log.d(TAG, "Removed batch file: ${file.name}")
+            deleted
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to remove batch $id: ${e.message}", e)
+            false
+        }
+    }
+
+    /** Removes exactly these batch ids; returns how many were deleted. */
+    fun removeBatches(ids: List<String>): Int = ids.count { removeBatch(it) }
     
     /**
      * Clears all stored batches
@@ -390,8 +400,10 @@ class OfflineBatchStorage(private val context: Context) {
     
     private fun cleanupExpiredBatches() {
         try {
+            // .json = pending; .corrupt = quarantined; .tmp = interrupted atomic write.
+            // All carry the timestamp in the filename and all expire on the same 7-day clock.
             val files = storageDirectory.listFiles()
-                ?.filter { it.extension == "json" }
+                ?.filter { it.extension == "json" || it.extension == "corrupt" || it.extension == "tmp" }
                 ?: return
             
             val now = System.currentTimeMillis()

--- a/sdk/src/main/java/io/bearound/sdk/utilities/SDKConfigStorage.kt
+++ b/sdk/src/main/java/io/bearound/sdk/utilities/SDKConfigStorage.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.SharedPreferences
 import io.bearound.sdk.models.ForegroundScanConfig
 import io.bearound.sdk.models.MaxQueuedPayloads
+import io.bearound.sdk.models.PeriodicReconciliationDefaults
 import io.bearound.sdk.models.SDKConfiguration
 import io.bearound.sdk.models.ScanPrecision
 
@@ -30,6 +31,10 @@ object SDKConfigStorage {
     private const val KEY_FG_SCAN_ICON = "fg_scan_icon"
     private const val KEY_FG_SCAN_CHANNEL_ID = "fg_scan_channel_id"
     private const val KEY_FG_SCAN_CHANNEL_NAME = "fg_scan_channel_name"
+    // Periodic reconciliation keys
+    private const val KEY_PERIODIC_ENABLED = "periodic_reconciliation_enabled"
+    private const val KEY_PERIODIC_INTERVAL = "periodic_reconciliation_interval_ms"
+    private const val KEY_PERIODIC_SCAN_DURATION = "periodic_scan_duration_ms"
 
     private fun getPrefs(context: Context): SharedPreferences {
         return context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
@@ -41,6 +46,9 @@ object SDKConfigStorage {
             putString(KEY_SCAN_PRECISION, config.scanPrecision.name)
             putInt(KEY_MAX_QUEUED_PAYLOADS, config.maxQueuedPayloads.value)
             putString(KEY_TECHNOLOGY, config.technology)
+            putBoolean(KEY_PERIODIC_ENABLED, config.periodicReconciliationEnabled)
+            putLong(KEY_PERIODIC_INTERVAL, config.periodicReconciliationIntervalMillis)
+            putLong(KEY_PERIODIC_SCAN_DURATION, config.periodicScanDurationMillis)
             putBoolean(KEY_IS_CONFIGURED, true)
             // Remove legacy keys if they exist
             remove(KEY_FOREGROUND_INTERVAL)
@@ -80,12 +88,26 @@ object SDKConfigStorage {
         // Default to "android-native" for configs persisted before 3.3.0
         val technology = prefs.getString(KEY_TECHNOLOGY, null) ?: "android-native"
 
+        // Configs persisted before the periodic-reconciliation fields existed restore
+        // the SDK defaults (feature ON, 20 min, 12s window). Values are re-sanitized on
+        // load so a corrupted/edited prefs file can't smuggle an out-of-range value in.
+        val periodicEnabled = prefs.getBoolean(KEY_PERIODIC_ENABLED, true)
+        val periodicInterval = PeriodicReconciliationDefaults.sanitizedInterval(
+            prefs.getLong(KEY_PERIODIC_INTERVAL, PeriodicReconciliationDefaults.DEFAULT_INTERVAL_MILLIS)
+        )
+        val periodicScanDuration = PeriodicReconciliationDefaults.sanitizedScanDuration(
+            prefs.getLong(KEY_PERIODIC_SCAN_DURATION, PeriodicReconciliationDefaults.DEFAULT_SCAN_DURATION_MILLIS)
+        )
+
         return SDKConfiguration(
             businessToken = businessToken,
             appId = appId,
             scanPrecision = scanPrecision,
             maxQueuedPayloads = maxQueuedPayloads,
-            technology = technology
+            technology = technology,
+            periodicReconciliationEnabled = periodicEnabled,
+            periodicReconciliationIntervalMillis = periodicInterval,
+            periodicScanDurationMillis = periodicScanDuration
         )
     }
 

--- a/sdk/src/test/java/io/bearound/sdk/background/PeriodicReconciliationSchedulingTest.kt
+++ b/sdk/src/test/java/io/bearound/sdk/background/PeriodicReconciliationSchedulingTest.kt
@@ -1,0 +1,123 @@
+package io.bearound.sdk.background
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.work.Configuration
+import androidx.work.WorkInfo
+import androidx.work.WorkManager
+import androidx.work.testing.SynchronousExecutor
+import androidx.work.testing.WorkManagerTestInitHelper
+import io.bearound.sdk.models.PeriodicReconciliationDefaults
+import io.bearound.sdk.models.SDKConfiguration
+import io.bearound.sdk.utilities.SDKConfigStorage
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class PeriodicReconciliationSchedulingTest {
+
+    private lateinit var context: Context
+    private lateinit var scheduler: BackgroundScheduler
+
+    private fun config(
+        enabled: Boolean = true,
+        intervalMs: Long = PeriodicReconciliationDefaults.DEFAULT_INTERVAL_MILLIS
+    ) = SDKConfiguration(
+        businessToken = "test-token",
+        appId = "io.test",
+        periodicReconciliationEnabled = enabled,
+        periodicReconciliationIntervalMillis = intervalMs
+    )
+
+    private fun uniqueWorkInfos(): List<WorkInfo> =
+        WorkManager.getInstance(context)
+            .getWorkInfosForUniqueWork(BeaconSyncWorker.WORK_NAME)
+            .get()
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        val wmConfig = Configuration.Builder()
+            .setExecutor(SynchronousExecutor())
+            .build()
+        WorkManagerTestInitHelper.initializeTestWorkManager(context, wmConfig)
+        // The scheduler is a process-wide singleton with a lazy WorkManager handle —
+        // in Robolectric each test gets a fresh Application (and a fresh test
+        // WorkManager), so the singleton from the previous test would enqueue into an
+        // orphaned instance. Reset it so getInstance() rebinds to this test's context.
+        BackgroundScheduler::class.java.getDeclaredField("instance").apply {
+            isAccessible = true
+            set(null, null)
+        }
+        scheduler = BackgroundScheduler.getInstance(context)
+        // Persisted config is the scheduler's source of truth.
+        SDKConfigStorage.clearConfiguration(context)
+    }
+
+    @Test
+    fun `scheduling enqueues exactly one unique periodic work`() {
+        SDKConfigStorage.saveConfiguration(context, config())
+        scheduler.schedulePeriodicSync()
+
+        val infos = uniqueWorkInfos()
+        assertEquals(1, infos.size)
+        assertTrue(infos[0].state == WorkInfo.State.ENQUEUED || infos[0].state == WorkInfo.State.RUNNING)
+    }
+
+    @Test
+    fun `repeated scheduling does not accumulate requests`() {
+        SDKConfigStorage.saveConfiguration(context, config())
+        repeat(5) { scheduler.schedulePeriodicSync() }
+
+        assertEquals(1, uniqueWorkInfos().size)
+    }
+
+    @Test
+    fun `interval change updates the same unique work instead of duplicating`() {
+        SDKConfigStorage.saveConfiguration(context, config(intervalMs = 20L * 60L * 1000L))
+        scheduler.schedulePeriodicSync()
+
+        SDKConfigStorage.saveConfiguration(context, config(intervalMs = 60L * 60L * 1000L))
+        scheduler.refreshPeriodicReconciliation(config(intervalMs = 60L * 60L * 1000L))
+
+        assertEquals(1, uniqueWorkInfos().size)
+    }
+
+    @Test
+    fun `disabling cancels the unique periodic work`() {
+        SDKConfigStorage.saveConfiguration(context, config())
+        scheduler.schedulePeriodicSync()
+        assertEquals(1, uniqueWorkInfos().size)
+
+        SDKConfigStorage.saveConfiguration(context, config(enabled = false))
+        scheduler.refreshPeriodicReconciliation(config(enabled = false))
+
+        val infos = uniqueWorkInfos()
+        assertTrue(infos.isEmpty() || infos.all { it.state == WorkInfo.State.CANCELLED })
+    }
+
+    @Test
+    fun `re-enabling schedules the unique periodic work again`() {
+        SDKConfigStorage.saveConfiguration(context, config(enabled = false))
+        scheduler.refreshPeriodicReconciliation(config(enabled = false))
+
+        SDKConfigStorage.saveConfiguration(context, config(enabled = true))
+        scheduler.refreshPeriodicReconciliation(config(enabled = true))
+
+        val active = uniqueWorkInfos().filter { !it.state.isFinished }
+        assertEquals(1, active.size)
+    }
+
+    @Test
+    fun `scheduling with the feature disabled in storage does not enqueue`() {
+        SDKConfigStorage.saveConfiguration(context, config(enabled = false))
+        scheduler.schedulePeriodicSync()
+
+        val active = uniqueWorkInfos().filter { !it.state.isFinished }
+        assertTrue(active.isEmpty())
+    }
+}

--- a/sdk/src/test/java/io/bearound/sdk/background/PeriodicReconciliationSchedulingTest.kt
+++ b/sdk/src/test/java/io/bearound/sdk/background/PeriodicReconciliationSchedulingTest.kt
@@ -48,11 +48,9 @@ class PeriodicReconciliationSchedulingTest {
         // The scheduler is a process-wide singleton with a lazy WorkManager handle —
         // in Robolectric each test gets a fresh Application (and a fresh test
         // WorkManager), so the singleton from the previous test would enqueue into an
-        // orphaned instance. Reset it so getInstance() rebinds to this test's context.
-        BackgroundScheduler::class.java.getDeclaredField("instance").apply {
-            isAccessible = true
-            set(null, null)
-        }
+        // orphaned instance. (Reflection on the companion field broke on the RELEASE
+        // unit-test variant — hence the explicit test hook.)
+        BackgroundScheduler._resetForTesting()
         scheduler = BackgroundScheduler.getInstance(context)
         // Persisted config is the scheduler's source of truth.
         SDKConfigStorage.clearConfiguration(context)

--- a/sdk/src/test/java/io/bearound/sdk/models/PeriodicReconciliationDefaultsTest.kt
+++ b/sdk/src/test/java/io/bearound/sdk/models/PeriodicReconciliationDefaultsTest.kt
@@ -1,0 +1,94 @@
+package io.bearound.sdk.models
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class PeriodicReconciliationDefaultsTest {
+
+    private val min = PeriodicReconciliationDefaults.MINIMUM_INTERVAL_MILLIS
+    private val max = PeriodicReconciliationDefaults.MAXIMUM_INTERVAL_MILLIS
+    private val def = PeriodicReconciliationDefaults.DEFAULT_INTERVAL_MILLIS
+
+    @Test
+    fun `default interval is 20 minutes`() {
+        assertEquals(20L * 60L * 1000L, def)
+    }
+
+    @Test
+    fun `15 minutes is accepted as-is (WorkManager minimum)`() {
+        assertEquals(min, PeriodicReconciliationDefaults.sanitizedInterval(min))
+    }
+
+    @Test
+    fun `intervals between 15 and 20 minutes are accepted as-is`() {
+        val seventeen = 17L * 60L * 1000L
+        assertEquals(seventeen, PeriodicReconciliationDefaults.sanitizedInterval(seventeen))
+    }
+
+    @Test
+    fun `intervals above 20 minutes are accepted as-is`() {
+        val oneHour = 60L * 60L * 1000L
+        assertEquals(oneHour, PeriodicReconciliationDefaults.sanitizedInterval(oneHour))
+    }
+
+    @Test
+    fun `sub-15-minute intervals clamp to the WorkManager minimum with a warning`() {
+        // WorkManager silently raises these anyway — the SDK clamps loudly instead.
+        for (aggressive in listOf(1L, 60_000L, 5L * 60L * 1000L, min - 1)) {
+            assertEquals(min, PeriodicReconciliationDefaults.sanitizedInterval(aggressive))
+        }
+    }
+
+    @Test
+    fun `zero and negative intervals fall back to the default`() {
+        assertEquals(def, PeriodicReconciliationDefaults.sanitizedInterval(0L))
+        assertEquals(def, PeriodicReconciliationDefaults.sanitizedInterval(-1L))
+        assertEquals(def, PeriodicReconciliationDefaults.sanitizedInterval(Long.MIN_VALUE))
+    }
+
+    @Test
+    fun `effectively-never intervals clamp to the 24h ceiling`() {
+        assertEquals(max, PeriodicReconciliationDefaults.sanitizedInterval(7L * 24L * 60L * 60L * 1000L))
+        assertEquals(max, PeriodicReconciliationDefaults.sanitizedInterval(Long.MAX_VALUE))
+    }
+
+    @Test
+    fun `scan durations below 3s clamp up`() {
+        assertEquals(
+            PeriodicReconciliationDefaults.MINIMUM_SCAN_DURATION_MILLIS,
+            PeriodicReconciliationDefaults.sanitizedScanDuration(500L)
+        )
+    }
+
+    @Test
+    fun `scan durations above 30s clamp down`() {
+        for (oversized in listOf(31_000L, 60_000L, 500_000L)) {
+            assertEquals(
+                PeriodicReconciliationDefaults.MAXIMUM_SCAN_DURATION_MILLIS,
+                PeriodicReconciliationDefaults.sanitizedScanDuration(oversized)
+            )
+        }
+    }
+
+    @Test
+    fun `invalid scan durations fall back to the default`() {
+        assertEquals(
+            PeriodicReconciliationDefaults.DEFAULT_SCAN_DURATION_MILLIS,
+            PeriodicReconciliationDefaults.sanitizedScanDuration(0L)
+        )
+        assertEquals(
+            PeriodicReconciliationDefaults.DEFAULT_SCAN_DURATION_MILLIS,
+            PeriodicReconciliationDefaults.sanitizedScanDuration(-5L)
+        )
+    }
+
+    @Test
+    fun `in-range scan durations pass through`() {
+        assertEquals(12_000L, PeriodicReconciliationDefaults.sanitizedScanDuration(12_000L))
+        assertEquals(3_000L, PeriodicReconciliationDefaults.sanitizedScanDuration(3_000L))
+        assertEquals(30_000L, PeriodicReconciliationDefaults.sanitizedScanDuration(30_000L))
+    }
+}

--- a/sdk/src/test/java/io/bearound/sdk/utilities/OfflineBatchStorageTest.kt
+++ b/sdk/src/test/java/io/bearound/sdk/utilities/OfflineBatchStorageTest.kt
@@ -1,0 +1,128 @@
+package io.bearound.sdk.utilities
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import io.bearound.sdk.models.Beacon
+import java.io.File
+import java.util.Date
+import java.util.UUID
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class OfflineBatchStorageTest {
+
+    private lateinit var context: Context
+    private lateinit var storage: OfflineBatchStorage
+
+    private fun beacon(minor: Int = 1) = Beacon(
+        uuid = UUID.fromString("11111111-2222-3333-4444-555555555555"),
+        major = 1,
+        minor = minor,
+        rssi = -60,
+        proximity = Beacon.Proximity.NEAR,
+        accuracy = 1.0,
+        timestamp = Date()
+    )
+
+    private fun storageDir(): File {
+        // Mirrors the production path: context.getDir(name, MODE_PRIVATE) prefixes "app_".
+        return File(context.filesDir.parentFile, "app_com.bearound.sdk.batches")
+    }
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        storageDir().deleteRecursively()
+        storage = OfflineBatchStorage(context)
+    }
+
+    @Test
+    fun `saveBatchReturningId returns an id and the batch is readable back`() {
+        val id = storage.saveBatchReturningId(listOf(beacon()))
+        assertNotNull(id)
+        val records = storage.loadAllRecords()
+        assertEquals(1, records.size)
+        assertEquals(id, records[0].id)
+        assertEquals(1, records[0].beacons.size)
+    }
+
+    @Test
+    fun `removeBatch removes exactly the given id even when a newer batch exists`() {
+        val first = storage.saveBatchReturningId(listOf(beacon(1)))!!
+        val second = storage.saveBatchReturningId(listOf(beacon(2)))!!
+
+        // Removal by id is immune to ordering — the scenario the positional
+        // removeOldestBatch() got wrong when saves ran between load and remove.
+        assertTrue(storage.removeBatch(second))
+        val remaining = storage.loadAllRecords()
+        assertEquals(1, remaining.size)
+        assertEquals(first, remaining[0].id)
+    }
+
+    @Test
+    fun `removeBatches removes only the requested ids`() {
+        val a = storage.saveBatchReturningId(listOf(beacon(1)))!!
+        val b = storage.saveBatchReturningId(listOf(beacon(2)))!!
+        val c = storage.saveBatchReturningId(listOf(beacon(3)))!!
+
+        assertEquals(2, storage.removeBatches(listOf(a, c)))
+        val remaining = storage.loadAllRecords()
+        assertEquals(1, remaining.size)
+        assertEquals(b, remaining[0].id)
+    }
+
+    @Test
+    fun `batches from another tenant are not returned nor counted`() {
+        storage.currentTenantId = "tenant-a"
+        val idA = storage.saveBatchReturningId(listOf(beacon(1)))!!
+
+        storage.currentTenantId = "tenant-b"
+        assertTrue(storage.loadAllRecords().isEmpty())
+
+        // Switching back exposes tenant A's queue again — nothing was destroyed.
+        storage.currentTenantId = "tenant-a"
+        assertEquals(listOf(idA), storage.loadAllRecords().map { it.id })
+    }
+
+    @Test
+    fun `legacy batches without tenant are treated as current`() {
+        // Written with no tenant configured (pre-upgrade file).
+        val legacyId = storage.saveBatchReturningId(listOf(beacon(1)))!!
+
+        storage.currentTenantId = "tenant-a"
+        assertEquals(listOf(legacyId), storage.loadAllRecords().map { it.id })
+    }
+
+    @Test
+    fun `corrupted file is quarantined not silently deleted`() {
+        storage.saveBatchReturningId(listOf(beacon(1)))
+        val dir = storageDir()
+        val corrupted = File(dir, "${System.currentTimeMillis()}_zzz.json")
+        corrupted.writeText("{ not json !!")
+
+        val records = storage.loadAllRecords()
+        assertEquals(1, records.size) // the good one still loads
+
+        assertFalse(corrupted.exists())
+        assertTrue(
+            "expected a .corrupt quarantine file",
+            dir.listFiles()!!.any { it.extension == "corrupt" }
+        )
+    }
+
+    @Test
+    fun `interrupted atomic write (tmp file) is invisible to readers`() {
+        val dir = storageDir()
+        File(dir, "${System.currentTimeMillis()}_abc.json.tmp").writeText("{ partial")
+
+        assertTrue(storage.loadAllRecords().isEmpty())
+        assertEquals(0, storage.getBatchCount())
+    }
+}

--- a/sdk/src/test/java/io/bearound/sdk/utilities/OfflineBatchStorageTest.kt
+++ b/sdk/src/test/java/io/bearound/sdk/utilities/OfflineBatchStorageTest.kt
@@ -118,6 +118,19 @@ class OfflineBatchStorageTest {
     }
 
     @Test
+    fun `quarantineBatch removes the batch from the send queue but keeps the file`() {
+        val poison = storage.saveBatchReturningId(listOf(beacon(1)))!!
+        val healthy = storage.saveBatchReturningId(listOf(beacon(2)))!!
+
+        assertTrue(storage.quarantineBatch(poison))
+
+        // The queue moves on without the rejected batch (head-of-line unblocked)...
+        assertEquals(listOf(healthy), storage.loadAllRecords().map { it.id })
+        // ...and the evidence file survives as .rejected for diagnosis.
+        assertTrue(storageDir().listFiles()!!.any { it.extension == "rejected" })
+    }
+
+    @Test
     fun `interrupted atomic write (tmp file) is invisible to readers`() {
         val dir = storageDir()
         File(dir, "${System.currentTimeMillis()}_abc.json.tmp").writeText("{ partial")

--- a/sdk/src/test/java/io/bearound/sdk/utilities/PeriodicConfigPersistenceTest.kt
+++ b/sdk/src/test/java/io/bearound/sdk/utilities/PeriodicConfigPersistenceTest.kt
@@ -1,0 +1,92 @@
+package io.bearound.sdk.utilities
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import io.bearound.sdk.models.PeriodicReconciliationDefaults
+import io.bearound.sdk.models.SDKConfiguration
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class PeriodicConfigPersistenceTest {
+
+    private lateinit var context: Context
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        SDKConfigStorage.clearConfiguration(context)
+    }
+
+    @Test
+    fun `periodic fields survive a save-load roundtrip`() {
+        val config = SDKConfiguration(
+            businessToken = "roundtrip-token",
+            appId = "io.test",
+            periodicReconciliationEnabled = false,
+            periodicReconciliationIntervalMillis = 60L * 60L * 1000L,
+            periodicScanDurationMillis = 8_000L
+        )
+        SDKConfigStorage.saveConfiguration(context, config)
+
+        val loaded = SDKConfigStorage.loadConfiguration(context)
+        assertNotNull(loaded)
+        assertEquals(false, loaded!!.periodicReconciliationEnabled)
+        assertEquals(60L * 60L * 1000L, loaded.periodicReconciliationIntervalMillis)
+        assertEquals(8_000L, loaded.periodicScanDurationMillis)
+    }
+
+    @Test
+    fun `legacy config without periodic fields restores the defaults`() {
+        // Persist a config, then strip the new keys to simulate prefs written by an
+        // SDK version that predates the feature.
+        SDKConfigStorage.saveConfiguration(
+            context,
+            SDKConfiguration(businessToken = "legacy-token", appId = "io.test")
+        )
+        context.getSharedPreferences("bearound_sdk_config", Context.MODE_PRIVATE).edit()
+            .remove("periodic_reconciliation_enabled")
+            .remove("periodic_reconciliation_interval_ms")
+            .remove("periodic_scan_duration_ms")
+            .commit()
+
+        val loaded = SDKConfigStorage.loadConfiguration(context)
+        assertNotNull(loaded)
+        assertEquals(true, loaded!!.periodicReconciliationEnabled)
+        assertEquals(
+            PeriodicReconciliationDefaults.DEFAULT_INTERVAL_MILLIS,
+            loaded.periodicReconciliationIntervalMillis
+        )
+        assertEquals(
+            PeriodicReconciliationDefaults.DEFAULT_SCAN_DURATION_MILLIS,
+            loaded.periodicScanDurationMillis
+        )
+    }
+
+    @Test
+    fun `out-of-range persisted values are re-sanitized on load`() {
+        // A corrupted/hand-edited prefs file cannot smuggle an aggressive interval in.
+        SDKConfigStorage.saveConfiguration(
+            context,
+            SDKConfiguration(businessToken = "tampered", appId = "io.test")
+        )
+        context.getSharedPreferences("bearound_sdk_config", Context.MODE_PRIVATE).edit()
+            .putLong("periodic_reconciliation_interval_ms", 60_000L) // 1 min
+            .putLong("periodic_scan_duration_ms", 500_000L) // 500 s
+            .commit()
+
+        val loaded = SDKConfigStorage.loadConfiguration(context)!!
+        assertEquals(
+            PeriodicReconciliationDefaults.MINIMUM_INTERVAL_MILLIS,
+            loaded.periodicReconciliationIntervalMillis
+        )
+        assertEquals(
+            PeriodicReconciliationDefaults.MAXIMUM_SCAN_DURATION_MILLIS,
+            loaded.periodicScanDurationMillis
+        )
+    }
+}


### PR DESCRIPTION
## O que este PR entrega

Três blocos, em commits sequenciais:

1. **Hardening (rounds 1 e 2)** — bugs críticos de detecção e entrega + remoção de API morta (breaking aprovado)
2. **Reconciliação periódica configurável** (WorkManager)

Nenhum comportamento OEM validado em campo foi alterado; os pontos da auditoria externa que contrariavam design validado foram rejeitados com evidência (lista no fim).

---

## 1. Hardening

**Detecção:**
- **Exit de região era edge-triggered e podia NUNCA disparar** (mapa esvaziava antes da graça → condição nunca reavaliada → \"dentro\" para sempre + metadata scan eterno). Agora level-triggered sobre `lastBeaconSeenAt` — mesma doutrina do iOS.
- Enter/exit ligam/desligam o ranging (o comentário do código prometia o wiring que não existia).
- **Reserve-before-kill na quota de scan**: todos os 4 caminhos de restart adquirem o token do substituto ANTES de derrubar a sessão atual (1 token por flip, não 2; nunca mata scan saudável sem reposição garantida).
- `EXTRA_ERROR_CODE` do PendingIntent tratado (TOO_FREQUENTLY congela o budget); registro só é publicado APÓS o aceite do stack (quota negada não deixava mais `isRegistered` mentiroso com retry morto).
- Restore de zona valida a idade da ÚLTIMA DETECÇÃO (não do snapshot) — fim do \"dentro mas passivo\"; `lastBeaconSeenAt` persiste com throttle de 60s em permanências longas.
- BT off→on recupera o metadata scan (flag zumbi derrubada no STATE_OFF, re-arme no STATE_ON); `onScanFailed` derruba a flag em todos os códigos; `desiredScanning`/`pendingRestart` com cancelamento no stop.
- Gate de permissão pré-Android-12 corrigido (era `hasLocation || true`); `isConnectable` real via `ScanResult.isConnectable()`.

**Entrega:**
- **Single-flight sync** (Mutex+Deferred): chamadores concorrentes aguardam o resultado REAL (fim do `isSyncing` racy com sucesso fake).
- **Persist-before-send** com remoção por ID exato; escrita atômica (tmp+fsync+rename); quarentena `.corrupt`; **isolamento por tenant** (fingerprint SHA-256 do token nos batches).
- **Head-of-line guard**: rejeição permanente (400/401/403/404/413/422) dispara bisect individual + quarentena `.rejected` — um batch envenenado não trava mais a fila por 7 dias (caso real: os 422 do 3.4.5). Permanente não alimenta o circuit breaker.
- Watchdog delega ao `ImmediateSyncWorker` (janela real de execução) e só se reagenda enquanto o scanning é desejado; crash envelope em disco (a coroutine do uncaught handler morria com o processo); lifecycle observer na main (crash latente em cold start via worker); `coldStart` verdadeiro só no 1º payload; FGS revive recarrega config persistida + update via `NotificationManager.notify`.

**Removidos (breaking aprovado; wrappers Flutter/RN verificados — não usam):** `startQuickScan`/`stopQuickScan`, `pauseScanning`/`resumeScanning`, `pauseRanging`, `onBackgroundRangingComplete`, `emptyBeaconCount`, props `precision*` de duty cycle, `currentScanDuration`/`currentPauseDuration`, `isPeriodicScanningEnabled`.

## 2. Reconciliação periódica configurável (WorkManager)

O `BeaconSyncWorker` (já um `PeriodicWorkRequest` único com `UPDATE` policy) virou camada de reconciliação de primeira classe:

```kotlin
sdk.configure(
    businessToken = token,
    periodicReconciliationEnabled = true,                     // default true
    periodicReconciliationIntervalMillis = 30L * 60L * 1000L, // default 20 min
    periodicScanDurationMillis = 12_000L                      // default 12 s
)
```

- **Guard rails**: intervalo 15 min (mínimo duro do WorkManager) – 24 h; janela 3–30 s. Fora da faixa = clamp com log ERROR explicando o porquê — nunca silencioso (o próprio WorkManager eleva sub-15-min mudo; o SDK avisa onde a plataforma se cala), nunca crash (doutrina never-crash-the-host — por isso o `require()` da spec não foi usado; decisão registrada).
- **Sem constraint de rede** (removida a `NetworkType.CONNECTED`): o worker coleta e persiste offline; a entrega fica com o pipeline de retry.
- **Política de execução**: intenção do host manda (`stopScanning()` → só drena); Battery Saver/térmico severo → sem janela de coleta; senão: um self-heal budget-guarded do registro PendingIntent + espera passiva (NUNCA registra scanner próprio) de até a janela configurada pelos scanners contínuos — detecção recente = zero espera. `ensureActive()` no loop responde a cancelamento.
- Config persistida é a fonte de verdade do scheduler (cold starts via worker/receiver/boot honram os valores); valores re-sanitizados no load (prefs adulterado não injeta intervalo agressivo).

## Validação

- **114 testes, 0 falhas em 3 execuções completas consecutivas** (+27 novos nos dois blocos: sanitização, persistência, agendamento WorkManager via work-testing — unicidade, UPDATE, cancel/re-enable)
- `lintDebug` limpo; `:app` e `:BearoundScan` compilam
- Dep de teste nova: `androidx.work:work-testing:2.10.1`; runtime WorkManager 2.9.0→2.10.1

## Validação em aparelho real (pós-merge, bancada)

Exit de região cronometrado (entrar→sair→~5 min); BT off→on dentro da região; kill após 10+ min na zona (sem exit/enter falso no relaunch); batch 422 forjado na fila; worker via `WorkManagerTestDriver`; Battery Saver durante a janela; matriz OEM de sempre (Pixel/Samsung/Xiaomi/Moto/realme). Limitações da plataforma: Doze/OEM podem atrasar o worker; force stop suspende até o próximo launch; WorkManager não garante horário.