### PR TITLE
feat: observações de Wi-Fi e localização no payload (SDK Android)

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,50 @@ see the [AI setup prompt](./AI-AGENT-SETUP.md), step 2).
 | `POST_NOTIFICATIONS` | Foreground-service notification on Android 13+ |
 | `RECEIVE_BOOT_COMPLETED` | Re-arm scanning after reboot |
 | `FOREGROUND_SERVICE`, `FOREGROUND_SERVICE_CONNECTED_DEVICE` | Optional foreground service (see [Google Play review](#google-play-review--what-the-manifest-merge-means-for-your-app)) |
+| `ACCESS_WIFI_STATE` | Read the connected access point and the system's cached scan results (install-time, no prompt) |
+| `NEARBY_WIFI_DEVICES` | Alternative to location for reading neighbouring access points on Android 13+ — see [Wi-Fi observations](#wi-fi-observations) |
+
+`CHANGE_WIFI_STATE` is **not** declared: the SDK reads the system's cached scan results and
+never triggers a scan of its own.
+
+### Wi-Fi observations
+
+Alongside each beacon sighting the SDK reports the **access points visible at that moment**.
+The purpose is positioning coverage: an access point seen repeatedly next to a known beacon
+gets a position of its own, and from then on it can place a device even where no beacon
+reaches.
+
+**Nothing here identifies a network.** The SDK never sends the network name (SSID). What
+travels is `apId` — a one-way SHA-256 hash of the access point's hardware address,
+canonicalised so that the same router produces the same identifier on Android and on iOS.
+
+| Field | Meaning |
+|---|---|
+| `apId` | Hashed access point identity (16 hex chars) |
+| `rssi` | Signal strength in dBm |
+| `connected` | Whether this is the access point the device is joined to |
+| `frequencyMhz` | Channel frequency |
+| `timestamp` | When the access point was seen (not when the payload was sent) |
+
+Each payload also carries the device's **last known** location as context — the SDK never
+requests an active fix, so there is no extra GPS wake-up and no battery cost.
+
+**It is entirely opt-in, and the SDK never prompts.** Collection happens only if your app
+already holds the permissions:
+
+| Your app grants | What the SDK reports |
+|---|---|
+| Nothing | No `wifis[]` at all — payload identical to before |
+| `ACCESS_WIFI_STATE` only | The connected access point |
+| Location **or** `NEARBY_WIFI_DEVICES` (13+) | The connected access point **and** its neighbours |
+
+Two privacy behaviours are built in: networks whose name ends in `_nomap` (the opt-out
+convention honoured by Google and Mozilla) are dropped on the device, and placeholder
+addresses that Android returns when a permission is missing are discarded rather than hashed.
+
+> **Migration note:** the old `network.wifiSSID` field, which carried the network name in
+> clear text, is replaced by `network.apId`. Nothing downstream needed the name — only a
+> stable identity.
 
 ### Permission model: `neverForLocation` and location
 

--- a/README.md
+++ b/README.md
@@ -258,9 +258,9 @@ The purpose is positioning coverage: an access point seen repeatedly next to a k
 gets a position of its own, and from then on it can place a device even where no beacon
 reaches.
 
-**Nothing here identifies a network.** The SDK never sends the network name (SSID). What
-travels is `apId` — a one-way SHA-256 hash of the access point's hardware address,
-canonicalised so that the same router produces the same identifier on Android and on iOS.
+The identity that matters is `apId` — a one-way SHA-256 hash of the access point's hardware
+address, canonicalised so that the same router produces the same identifier on Android and
+on iOS.
 
 | Field | Meaning |
 |---|---|
@@ -269,6 +269,12 @@ canonicalised so that the same router produces the same identifier on Android an
 | `connected` | Whether this is the access point the device is joined to |
 | `frequencyMhz` | Channel frequency |
 | `timestamp` | When the access point was seen (not when the payload was sent) |
+| `ssid` | Network name — **temporary**, see below |
+
+> **`ssid` and `network.wifiSSID` are transitional.** They ride along so the collection can
+> be validated against real networks while the access-point map is being built. Nothing
+> downstream consumes them — `apId` is the identity. They are marked for removal in the
+> source, so dropping them later is a single grep.
 
 Each payload also carries the device's **last known** location as context — the SDK never
 requests an active fix, so there is no extra GPS wake-up and no battery cost.
@@ -286,9 +292,8 @@ Two privacy behaviours are built in: networks whose name ends in `_nomap` (the o
 convention honoured by Google and Mozilla) are dropped on the device, and placeholder
 addresses that Android returns when a permission is missing are discarded rather than hashed.
 
-> **Migration note:** the old `network.wifiSSID` field, which carried the network name in
-> clear text, is replaced by `network.apId`. Nothing downstream needed the name — only a
-> stable identity.
+> **Migration note:** `network.apId` joins `network.wifiSSID` and is the field consumers
+> should read — a stable identity that survives the SSID being dropped later.
 
 ### Permission model: `neverForLocation` and location
 

--- a/release/.gitkeep
+++ b/release/.gitkeep
@@ -1,1 +1,0 @@
-# Pasta para binários .aar gerados automaticamente

--- a/sdk/src/main/AndroidManifest.xml
+++ b/sdk/src/main/AndroidManifest.xml
@@ -34,9 +34,29 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
     <!-- Wi-Fi state (normal permission, granted at install, no user prompt) — required by
-         WifiManager for the wifiSSID telemetry field; without it the SSID is always null
-         in host apps that only integrate the SDK. -->
+         WifiManager to read the connected access point and the system's cached scan
+         results. Without it the SDK reports no Wi-Fi observations at all. -->
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+
+    <!-- Nearby Wi-Fi devices (Android 13+). Reading the neighbouring access points needs
+         ACCESS_FINE_LOCATION on every version OR this permission on API 33+; either one
+         is enough, and the SDK checks both at runtime. Declared WITHOUT neverForLocation
+         on purpose: the observations exist precisely to be associated with a position,
+         so asserting otherwise would be false.
+         NOT a hard requirement — a host that never grants it simply sends no `wifis[]`,
+         and every other SDK feature behaves exactly as before. The SDK never prompts. -->
+    <uses-permission android:name="android.permission.NEARBY_WIFI_DEVICES"
+        tools:targetApi="tiramisu" />
+
+    <!-- NO CHANGE_WIFI_STATE: the SDK reads the system's cached scan results and never
+         calls startScan(). Android throttles scans to 4 per 2 minutes anyway, and every
+         other app on the phone already refreshes that cache — requesting our own would
+         cost battery and buy nothing. -->
+
+    <!-- Wi-Fi hardware, required="false" for the same reason as Bluetooth below: this
+         manifest merges into the host's, and a required feature would hide client apps
+         from Play Store devices that lack it. -->
+    <uses-feature android:name="android.hardware.wifi" android:required="false" />
 
     <!-- Notifications permission (Android 13+) -->
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />

--- a/sdk/src/main/java/io/bearound/sdk/models/DeviceLocation.kt
+++ b/sdk/src/main/java/io/bearound/sdk/models/DeviceLocation.kt
@@ -1,0 +1,23 @@
+package io.bearound.sdk.models
+
+/**
+ * Where the device was, as context for the observations in the same payload.
+ *
+ * Always the platform's **last known** fix — the SDK never requests an active one,
+ * so this costs no extra battery and no GPS wake-up.
+ *
+ * @property timestamp  epoch millis **of the fix**, not of the payload. A fix can be
+ *                      minutes old; the backend needs to know that to weigh it.
+ * @property source     which provider produced it: `gps`, `network`, `fused` or `passive`
+ * @property isMocked   true when the fix came from a mock provider — anti-fraud signal
+ *                      that only Android can offer
+ */
+data class DeviceLocation(
+    val latitude: Double,
+    val longitude: Double,
+    val accuracy: Float? = null,
+    val altitude: Double? = null,
+    val timestamp: Long,
+    val source: String,
+    val isMocked: Boolean? = null
+)

--- a/sdk/src/main/java/io/bearound/sdk/models/UserDevice.kt
+++ b/sdk/src/main/java/io/bearound/sdk/models/UserDevice.kt
@@ -27,7 +27,11 @@ data class UserDevice(
     val coldStart: Boolean,
     val lowPowerMode: Boolean?,
     val locationAccuracy: String?,
-    val wifiSSID: String?,
+    /**
+     * Hash of the connected access point's BSSID — replaces the raw `wifiSSID`, which
+     * leaked the network name (and therefore the household) in clear text.
+     */
+    val apId: String?,
     val connectionMetered: Boolean?,
     val connectionExpensive: Boolean?,
     val os: String = "Android",
@@ -37,6 +41,16 @@ data class UserDevice(
     val systemLanguage: String,
     val thermalState: String,
     val systemUptimeMs: Long,
-    val sdkVersion: Int
+    val sdkVersion: Int,
+    /**
+     * Access points visible at collection time. Empty when the host app lacks the
+     * permissions — the SDK never asks the user for anything on its own.
+     */
+    val wifis: List<WifiObservation> = emptyList(),
+    /**
+     * Last known fix, as context for [wifis] and for the beacons in the same payload.
+     * Null when unavailable; the SDK never requests an active fix.
+     */
+    val location: DeviceLocation? = null
 )
 

--- a/sdk/src/main/java/io/bearound/sdk/models/UserDevice.kt
+++ b/sdk/src/main/java/io/bearound/sdk/models/UserDevice.kt
@@ -27,11 +27,16 @@ data class UserDevice(
     val coldStart: Boolean,
     val lowPowerMode: Boolean?,
     val locationAccuracy: String?,
-    /**
-     * Hash of the connected access point's BSSID — replaces the raw `wifiSSID`, which
-     * leaked the network name (and therefore the household) in clear text.
-     */
+    /** Hash of the connected access point's BSSID — the identity the backend uses. */
     val apId: String?,
+    /**
+     * Name of the connected network.
+     *
+     * **Temporary — kept for validating the collection while the access-point map is being
+     * built.** [apId] is the field that matters; remove this one (and `WifiObservation.ssid`)
+     * once the collection is trusted.
+     */
+    val wifiSSID: String?,
     val connectionMetered: Boolean?,
     val connectionExpensive: Boolean?,
     val os: String = "Android",

--- a/sdk/src/main/java/io/bearound/sdk/models/WifiObservation.kt
+++ b/sdk/src/main/java/io/bearound/sdk/models/WifiObservation.kt
@@ -3,10 +3,9 @@ package io.bearound.sdk.models
 /**
  * One access point seen by the device at a point in time.
  *
- * Carries no network name: [apId] is a one-way hash of the BSSID, so the payload
- * never reveals which network the user is on.
- *
- * @property apId          canonical hash of the BSSID (16 hex chars)
+ * @property apId          canonical hash of the BSSID (16 hex chars) — the identity the
+ *                         backend actually uses
+ * @property ssid          TEMPORARY, see below
  * @property rssi          signal strength in dBm; null when the platform does not expose it
  * @property connected     true when this is the access point the device is joined to
  * @property frequencyMhz  channel frequency (2412–5825); null when unavailable
@@ -14,6 +13,16 @@ package io.bearound.sdk.models
  */
 data class WifiObservation(
     val apId: String,
+    /**
+     * Human-readable network name.
+     *
+     * **Temporary — for validating the collection against real networks while the map is
+     * being built.** Nothing downstream consumes it: [apId] is the identity. Remove this
+     * property, its sibling `UserDevice.wifiSSID`, and both payload fields once the
+     * collection is trusted — a network name identifies a household, so it should not
+     * outlive its debugging purpose.
+     */
+    val ssid: String? = null,
     val rssi: Int? = null,
     val connected: Boolean = false,
     val frequencyMhz: Int? = null,

--- a/sdk/src/main/java/io/bearound/sdk/models/WifiObservation.kt
+++ b/sdk/src/main/java/io/bearound/sdk/models/WifiObservation.kt
@@ -1,0 +1,21 @@
+package io.bearound.sdk.models
+
+/**
+ * One access point seen by the device at a point in time.
+ *
+ * Carries no network name: [apId] is a one-way hash of the BSSID, so the payload
+ * never reveals which network the user is on.
+ *
+ * @property apId          canonical hash of the BSSID (16 hex chars)
+ * @property rssi          signal strength in dBm; null when the platform does not expose it
+ * @property connected     true when this is the access point the device is joined to
+ * @property frequencyMhz  channel frequency (2412–5825); null when unavailable
+ * @property timestamp     epoch millis of the observation itself, not of the payload
+ */
+data class WifiObservation(
+    val apId: String,
+    val rssi: Int? = null,
+    val connected: Boolean = false,
+    val frequencyMhz: Int? = null,
+    val timestamp: Long
+)

--- a/sdk/src/main/java/io/bearound/sdk/network/APIClient.kt
+++ b/sdk/src/main/java/io/bearound/sdk/network/APIClient.kt
@@ -232,6 +232,38 @@ class APIClient(private val configuration: SDKConfiguration) {
         // Device info
         payload.put("device", buildDevicePayload(userDevice))
 
+        // Wi-Fi observations and location ride at the TOP of the envelope, beside
+        // `beacons`, because they describe the sighting — not the device. Both are
+        // omitted entirely when unavailable, so a host without the permissions sends
+        // exactly the payload it sends today.
+        if (userDevice.wifis.isNotEmpty()) {
+            val wifisArray = JSONArray()
+            userDevice.wifis.forEach { wifi ->
+                wifisArray.put(JSONObject().apply {
+                    put("apId", wifi.apId)
+                    put("connected", wifi.connected)
+                    put("timestamp", wifi.timestamp)
+                    wifi.rssi?.let { put("rssi", it) }
+                    wifi.frequencyMhz?.let { put("frequencyMhz", it) }
+                })
+            }
+            payload.put("wifis", wifisArray)
+        }
+
+        userDevice.location?.let { location ->
+            payload.put("location", JSONObject().apply {
+                put("latitude", location.latitude)
+                put("longitude", location.longitude)
+                // Timestamp OF THE FIX, not of the payload — a fix can be minutes old
+                // and the backend has to be able to tell.
+                put("timestamp", location.timestamp)
+                put("source", location.source)
+                location.accuracy?.let { put("accuracy", it) }
+                location.altitude?.let { put("altitude", it) }
+                location.isMocked?.let { put("isMocked", it) }
+            })
+        }
+
         // User properties (if any)
         if (userProperties?.hasProperties == true) {
             val userPropsObj = JSONObject(userProperties.toDictionary())
@@ -273,11 +305,11 @@ class APIClient(private val configuration: SDKConfiguration) {
         }
         payload.put("battery", battery)
 
-        // Network
+        // Network — carries the hashed access point, never the network name.
         val network = JSONObject().apply {
             put("type", device.networkType)
             device.cellularGeneration?.let { put("cellularGeneration", it) }
-            device.wifiSSID?.let { put("wifiSSID", it) }
+            device.apId?.let { put("apId", it) }
         }
         payload.put("network", network)
 

--- a/sdk/src/main/java/io/bearound/sdk/network/APIClient.kt
+++ b/sdk/src/main/java/io/bearound/sdk/network/APIClient.kt
@@ -245,6 +245,8 @@ class APIClient(private val configuration: SDKConfiguration) {
                     put("timestamp", wifi.timestamp)
                     wifi.rssi?.let { put("rssi", it) }
                     wifi.frequencyMhz?.let { put("frequencyMhz", it) }
+                    // Temporary, for validating the collection — see WifiObservation.ssid.
+                    wifi.ssid?.let { put("ssid", it) }
                 })
             }
             payload.put("wifis", wifisArray)
@@ -305,11 +307,12 @@ class APIClient(private val configuration: SDKConfiguration) {
         }
         payload.put("battery", battery)
 
-        // Network — carries the hashed access point, never the network name.
         val network = JSONObject().apply {
             put("type", device.networkType)
             device.cellularGeneration?.let { put("cellularGeneration", it) }
             device.apId?.let { put("apId", it) }
+            // Temporary, for validating the collection — see WifiObservation.ssid.
+            device.wifiSSID?.let { put("wifiSSID", it) }
         }
         payload.put("network", network)
 

--- a/sdk/src/main/java/io/bearound/sdk/utilities/ApIdentifier.kt
+++ b/sdk/src/main/java/io/bearound/sdk/utilities/ApIdentifier.kt
@@ -1,0 +1,63 @@
+package io.bearound.sdk.utilities
+
+import java.security.MessageDigest
+import java.util.Locale
+
+/**
+ * Canonical, privacy-preserving identifier for a Wi-Fi access point.
+ *
+ * The raw BSSID (the access point's MAC address) never leaves the device — only this
+ * hash does. Two properties make it work:
+ *
+ * 1. **Deterministic across platforms.** iOS reports the same address without leading
+ *    zeros (`b8:1e:61:0:95:e`) while Android keeps them (`b8:1e:61:00:95:0e`). Hashing
+ *    the raw strings would give one physical router two different identities and the
+ *    access-point map would never converge. Canonical form fixes that: each octet
+ *    left-padded to two hex digits, lowercased, joined without separators.
+ *
+ * 2. **Deterministic across devices.** No salt, on purpose — two phones that see the
+ *    same router must produce the same `apId`, otherwise cross-device correlation
+ *    (the whole point of the map) is impossible. This is pseudonymisation, not
+ *    anonymisation, and it is a conscious trade-off.
+ *
+ * Verified on-device: `b8:1e:61:00:95:0e` (Android) and `b8:1e:61:0:95:e` (iOS) both
+ * produce `2dc5d7448d0b3ef4`.
+ */
+internal object ApIdentifier {
+
+    /**
+     * BSSIDs the platform hands back when it will not tell us the real one — a missing
+     * permission, a disconnected interface, or a broadcast address. Hashing them would
+     * create a phantom access point shared by every device in that state.
+     */
+    private val PLACEHOLDERS = setOf(
+        "020000000000", // Android: location permission missing
+        "000000000000",
+        "ffffffffffff"
+    )
+
+    private val CANONICAL = Regex("[0-9a-f]{12}")
+
+    /**
+     * @return the 16-hex-character identifier, or `null` when [bssid] is absent,
+     *         malformed, or one of the platform placeholders.
+     */
+    fun from(bssid: String?): String? {
+        val raw = bssid?.trim()?.replace('-', ':') ?: return null
+        val octets = raw.split(':')
+        if (octets.size != 6) return null
+
+        val canonical = buildString {
+            for (octet in octets) {
+                if (octet.isEmpty() || octet.length > 2) return null
+                append(octet.padStart(2, '0').lowercase(Locale.ROOT))
+            }
+        }
+
+        if (!CANONICAL.matches(canonical)) return null
+        if (canonical in PLACEHOLDERS) return null
+
+        val digest = MessageDigest.getInstance("SHA-256").digest(canonical.toByteArray())
+        return digest.joinToString("") { "%02x".format(it) }.take(16)
+    }
+}

--- a/sdk/src/main/java/io/bearound/sdk/utilities/DeviceInfoCollector.kt
+++ b/sdk/src/main/java/io/bearound/sdk/utilities/DeviceInfoCollector.kt
@@ -27,6 +27,9 @@ import java.util.TimeZone
 class DeviceInfoCollector(
     private val context: Context
 ) {
+    private val wifiCollector by lazy { WifiCollector(context) }
+    private val locationCollector by lazy { LocationCollector(context) }
+
     companion object {
         /**
          * True only for the FIRST payload each process builds. The old constructor flag
@@ -43,6 +46,10 @@ class DeviceInfoCollector(
         bluetoothState: String,
         appInForeground: Boolean
     ): UserDevice {
+        // Collected once and reused: the connected AP is just the entry flagged as
+        // such, so there is no reason to hit the Wi-Fi stack twice.
+        val wifis = wifiCollector.collect()
+
         return UserDevice(
             deviceId = DeviceIdentifier.getDeviceId(context),
             pushToken = PushTokenStore.tokenForPayload(),
@@ -67,7 +74,9 @@ class DeviceInfoCollector(
             coldStart = firstPayloadOfProcess.getAndSet(false),
             lowPowerMode = isLowPowerMode(),
             locationAccuracy = getLocationAccuracy(locationPermission),
-            wifiSSID = getWifiSSID(),
+            // Replaces the old raw SSID: the network name identified the household in
+            // clear text, and nothing downstream needed the name — only a stable identity.
+            apId = wifis.firstOrNull { it.connected }?.apId,
             connectionMetered = isConnectionMetered(),
             connectionExpensive = isConnectionExpensive(),
             deviceName = getDeviceName(),
@@ -76,7 +85,9 @@ class DeviceInfoCollector(
             systemLanguage = Locale.getDefault().language,
             thermalState = getThermalState(),
             systemUptimeMs = SystemClock.elapsedRealtime(),
-            sdkVersion = Build.VERSION.SDK_INT
+            sdkVersion = Build.VERSION.SDK_INT,
+            wifis = wifis,
+            location = locationCollector.lastKnown()
         )
     }
 

--- a/sdk/src/main/java/io/bearound/sdk/utilities/DeviceInfoCollector.kt
+++ b/sdk/src/main/java/io/bearound/sdk/utilities/DeviceInfoCollector.kt
@@ -74,9 +74,9 @@ class DeviceInfoCollector(
             coldStart = firstPayloadOfProcess.getAndSet(false),
             lowPowerMode = isLowPowerMode(),
             locationAccuracy = getLocationAccuracy(locationPermission),
-            // Replaces the old raw SSID: the network name identified the household in
-            // clear text, and nothing downstream needed the name — only a stable identity.
             apId = wifis.firstOrNull { it.connected }?.apId,
+            // Temporary companion to apId while the collection is being validated.
+            wifiSSID = wifis.firstOrNull { it.connected }?.ssid,
             connectionMetered = isConnectionMetered(),
             connectionExpensive = isConnectionExpensive(),
             deviceName = getDeviceName(),

--- a/sdk/src/main/java/io/bearound/sdk/utilities/LocationCollector.kt
+++ b/sdk/src/main/java/io/bearound/sdk/utilities/LocationCollector.kt
@@ -1,0 +1,93 @@
+package io.bearound.sdk.utilities
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import android.location.Location
+import android.location.LocationManager
+import android.os.Build
+import android.util.Log
+import androidx.core.content.ContextCompat
+import io.bearound.sdk.models.DeviceLocation
+
+/**
+ * Reads the device's **last known** position — never requests a new one.
+ *
+ * That restraint is the whole design: an active fix wakes the GPS, costs battery and
+ * takes seconds. The last known fix is free, already in memory, and good enough to
+ * give the observations in this payload a place. It carries its own timestamp, so a
+ * stale fix is visible as stale to whoever consumes it rather than silently wrong.
+ */
+internal class LocationCollector(private val context: Context) {
+
+    companion object {
+        private const val TAG = "LocationCollector"
+
+        /** Older than this and the device has probably moved somewhere else entirely. */
+        private const val MAX_AGE_MS = 10 * 60 * 1000L
+    }
+
+    /**
+     * @return the freshest usable fix, or `null` when the host app has no location
+     *         permission, location is off, or every fix is too old. Never throws.
+     */
+    fun lastKnown(): DeviceLocation? {
+        if (!hasLocationPermission()) return null
+
+        val manager = context.getSystemService(Context.LOCATION_SERVICE) as? LocationManager
+            ?: return null
+
+        return try {
+            val now = System.currentTimeMillis()
+            manager.providers(enabledOnly = true)
+                .mapNotNull { provider ->
+                    @Suppress("MissingPermission")
+                    manager.getLastKnownLocation(provider)?.let { provider to it }
+                }
+                .filter { (_, location) -> now - location.time <= MAX_AGE_MS }
+                // Freshest wins; accuracy breaks ties.
+                .maxWithOrNull(
+                    compareBy<Pair<String, Location>> { it.second.time }
+                        .thenByDescending { it.second.accuracy }
+                )
+                ?.let { (provider, location) -> location.toDeviceLocation(provider) }
+        } catch (e: SecurityException) {
+            Log.d(TAG, "location unavailable: ${e.message}")
+            null
+        } catch (e: Exception) {
+            Log.d(TAG, "location failed: ${e.message}")
+            null
+        }
+    }
+
+    private fun hasLocationPermission(): Boolean =
+        ContextCompat.checkSelfPermission(
+            context, Manifest.permission.ACCESS_FINE_LOCATION
+        ) == PackageManager.PERMISSION_GRANTED ||
+            ContextCompat.checkSelfPermission(
+                context, Manifest.permission.ACCESS_COARSE_LOCATION
+            ) == PackageManager.PERMISSION_GRANTED
+
+    private fun LocationManager.providers(enabledOnly: Boolean): List<String> = try {
+        getProviders(enabledOnly)
+    } catch (e: Exception) {
+        emptyList()
+    }
+
+    private fun Location.toDeviceLocation(provider: String) = DeviceLocation(
+        latitude = latitude,
+        longitude = longitude,
+        accuracy = accuracy.takeIf { it > 0f },
+        altitude = if (hasAltitude()) altitude else null,
+        timestamp = time,
+        source = provider,
+        isMocked = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) isMock else isFromMockProviderCompat()
+    )
+
+    @Suppress("DEPRECATION")
+    private fun Location.isFromMockProviderCompat(): Boolean? = try {
+        isFromMockProvider
+    } catch (e: Exception) {
+        null
+    }
+}

--- a/sdk/src/main/java/io/bearound/sdk/utilities/WifiCollector.kt
+++ b/sdk/src/main/java/io/bearound/sdk/utilities/WifiCollector.kt
@@ -1,0 +1,157 @@
+package io.bearound.sdk.utilities
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import android.net.wifi.WifiManager
+import android.os.Build
+import android.os.SystemClock
+import android.util.Log
+import androidx.core.content.ContextCompat
+import io.bearound.sdk.models.WifiObservation
+
+/**
+ * Collects the Wi-Fi access points visible to the device.
+ *
+ * Two deliberate restraints:
+ *
+ * - **Never triggers a scan.** We read the system's cached results (`scanResults`)
+ *   instead of calling `startScan()`. Android throttles scans to 4 per 2 minutes
+ *   anyway, and every other app on the phone is already refreshing that cache for
+ *   us — asking for our own costs battery and buys nothing. It also keeps
+ *   `CHANGE_WIFI_STATE` out of the manifest.
+ *
+ * - **Opt-in by permission.** Nothing is collected unless the host app already holds
+ *   the permissions. A host that never asks for location simply sends no `wifis[]`,
+ *   and the rest of the SDK behaves exactly as before.
+ */
+internal class WifiCollector(private val context: Context) {
+
+    companion object {
+        private const val TAG = "WifiCollector"
+
+        /**
+         * Industry opt-out convention, honoured by Google and Mozilla: an SSID ending
+         * in `_nomap` means the owner does not want the access point mapped. We drop
+         * it on the device — it never reaches the network.
+         */
+        private const val NOMAP_SUFFIX = "_nomap"
+
+        /** Ceiling on how many neighbours travel in one payload. */
+        private const val MAX_OBSERVATIONS = 25
+
+        /** Results older than this are stale enough that the device likely moved. */
+        private const val MAX_RESULT_AGE_MS = 5 * 60 * 1000L
+    }
+
+    /**
+     * @return the visible access points, strongest first, or an empty list when the
+     *         host app lacks the permissions or Wi-Fi is off. Never throws.
+     */
+    fun collect(): List<WifiObservation> {
+        if (!hasWifiStatePermission()) return emptyList()
+
+        val wifiManager = context.applicationContext
+            .getSystemService(Context.WIFI_SERVICE) as? WifiManager ?: return emptyList()
+
+        val now = System.currentTimeMillis()
+        val observations = LinkedHashMap<String, WifiObservation>()
+
+        // The connected access point comes first: it is the strongest signal of where
+        // the device actually is, and it is the only one iOS can offer.
+        connectedObservation(wifiManager, now)?.let { observations[it.apId] = it }
+
+        // Neighbours need the scan permission on top of the Wi-Fi one.
+        if (hasScanPermission()) {
+            neighbourObservations(wifiManager, now).forEach { observation ->
+                observations.putIfAbsentCompat(observation.apId, observation)
+            }
+        }
+
+        return observations.values
+            .sortedByDescending { it.rssi ?: Int.MIN_VALUE }
+            .take(MAX_OBSERVATIONS)
+    }
+
+    // ── permissions ──────────────────────────────────────────────────────────────
+
+    /** Install-time permission — granted without a prompt, but a host can strip it. */
+    private fun hasWifiStatePermission(): Boolean = granted(Manifest.permission.ACCESS_WIFI_STATE)
+
+    /**
+     * Reading neighbours requires location on every version, plus `NEARBY_WIFI_DEVICES`
+     * as an alternative on Android 13+. Either one is enough.
+     */
+    private fun hasScanPermission(): Boolean {
+        val hasLocation = granted(Manifest.permission.ACCESS_FINE_LOCATION)
+        if (hasLocation) return true
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+            granted("android.permission.NEARBY_WIFI_DEVICES")
+    }
+
+    private fun granted(permission: String): Boolean =
+        ContextCompat.checkSelfPermission(context, permission) == PackageManager.PERMISSION_GRANTED
+
+    // ── collection ───────────────────────────────────────────────────────────────
+
+    @Suppress("DEPRECATION")
+    private fun connectedObservation(wifiManager: WifiManager, now: Long): WifiObservation? = try {
+        val info = wifiManager.connectionInfo
+        val apId = ApIdentifier.from(info?.bssid)
+        when {
+            apId == null -> null
+            info!!.networkId == -1 && info.bssid == null -> null
+            else -> WifiObservation(
+                apId = apId,
+                rssi = info.rssi.takeIf { it in -100..0 },
+                connected = true,
+                frequencyMhz = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                    info.frequency.takeIf { it > 0 }
+                } else null,
+                timestamp = now
+            )
+        }
+    } catch (e: SecurityException) {
+        Log.d(TAG, "connected AP unavailable: ${e.message}")
+        null
+    } catch (e: Exception) {
+        Log.d(TAG, "connected AP failed: ${e.message}")
+        null
+    }
+
+    private fun neighbourObservations(wifiManager: WifiManager, now: Long): List<WifiObservation> = try {
+        wifiManager.scanResults.orEmpty()
+            .asSequence()
+            .filterNot { it.SSID?.endsWith(NOMAP_SUFFIX, ignoreCase = true) == true }
+            .mapNotNull { result ->
+                val apId = ApIdentifier.from(result.BSSID) ?: return@mapNotNull null
+                val ageMs = resultAgeMs(result)
+                if (ageMs != null && ageMs > MAX_RESULT_AGE_MS) return@mapNotNull null
+                WifiObservation(
+                    apId = apId,
+                    rssi = result.level.takeIf { it in -100..0 },
+                    connected = false,
+                    frequencyMhz = result.frequency.takeIf { it > 0 },
+                    // The observation happened when the radio saw it, not when we read it.
+                    timestamp = if (ageMs != null) now - ageMs else now
+                )
+            }
+            .toList()
+    } catch (e: SecurityException) {
+        Log.d(TAG, "scan results unavailable: ${e.message}")
+        emptyList()
+    } catch (e: Exception) {
+        Log.d(TAG, "scan results failed: ${e.message}")
+        emptyList()
+    }
+
+    /** `timestamp` on a scan result is microseconds since boot, not epoch. */
+    private fun resultAgeMs(result: android.net.wifi.ScanResult): Long? =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1 && result.timestamp > 0) {
+            (SystemClock.elapsedRealtime() - result.timestamp / 1000).coerceAtLeast(0)
+        } else null
+
+    private fun <K, V> LinkedHashMap<K, V>.putIfAbsentCompat(key: K, value: V) {
+        if (!containsKey(key)) put(key, value)
+    }
+}

--- a/sdk/src/main/java/io/bearound/sdk/utilities/WifiCollector.kt
+++ b/sdk/src/main/java/io/bearound/sdk/utilities/WifiCollector.kt
@@ -103,6 +103,8 @@ internal class WifiCollector(private val context: Context) {
             info!!.networkId == -1 && info.bssid == null -> null
             else -> WifiObservation(
                 apId = apId,
+                // Temporary, for validating the collection — see WifiObservation.ssid.
+                ssid = info.ssid?.removeSurrounding("\"")?.takeIf { it != "<unknown ssid>" },
                 rssi = info.rssi.takeIf { it in -100..0 },
                 connected = true,
                 frequencyMhz = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
@@ -129,6 +131,8 @@ internal class WifiCollector(private val context: Context) {
                 if (ageMs != null && ageMs > MAX_RESULT_AGE_MS) return@mapNotNull null
                 WifiObservation(
                     apId = apId,
+                    // Temporary, for validating the collection — see WifiObservation.ssid.
+                    ssid = result.SSID?.takeIf { it.isNotBlank() },
                     rssi = result.level.takeIf { it in -100..0 },
                     connected = false,
                     frequencyMhz = result.frequency.takeIf { it > 0 },

--- a/sdk/src/test/java/io/bearound/sdk/utilities/ApIdentifierTest.kt
+++ b/sdk/src/test/java/io/bearound/sdk/utilities/ApIdentifierTest.kt
@@ -1,0 +1,71 @@
+package io.bearound.sdk.utilities
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * The canonicalisation is the one piece that silently breaks the whole access-point
+ * map if it drifts: iOS and Android must produce the SAME identifier for the SAME
+ * router, forever. These tests pin that contract.
+ */
+class ApIdentifierTest {
+
+    /**
+     * The value below was verified on real hardware during the POC — the office router
+     * seen from an Android phone and from an iPhone. If this assertion ever fails, every
+     * access point already mapped becomes unreachable under the new hash.
+     */
+    private val OFFICE_AP = "2dc5d7448d0b3ef4"
+
+    @Test
+    fun `android and ios formats agree on the same router`() {
+        val android = ApIdentifier.from("b8:1e:61:00:95:0e") // keeps leading zeros
+        val ios = ApIdentifier.from("b8:1e:61:0:95:e")       // drops them
+
+        assertEquals(OFFICE_AP, android)
+        assertEquals(OFFICE_AP, ios)
+    }
+
+    @Test
+    fun `case and separator do not change the identity`() {
+        assertEquals(OFFICE_AP, ApIdentifier.from("B8:1E:61:00:95:0E"))
+        assertEquals(OFFICE_AP, ApIdentifier.from("b8-1e-61-00-95-0e"))
+        assertEquals(OFFICE_AP, ApIdentifier.from("  b8:1e:61:00:95:0e  "))
+    }
+
+    @Test
+    fun `identifier is 16 hex characters`() {
+        val id = ApIdentifier.from("a4:33:d7:fa:48:b8")
+        assertNotNull(id)
+        assertEquals(16, id!!.length)
+        assertEquals(true, id.matches(Regex("[0-9a-f]{16}")))
+    }
+
+    @Test
+    fun `different routers get different identifiers`() {
+        val a = ApIdentifier.from("b8:1e:61:00:95:0e")
+        val b = ApIdentifier.from("b8:1e:61:00:95:0f")
+        assertEquals(false, a == b)
+    }
+
+    @Test
+    fun `platform placeholders are rejected`() {
+        // Android hands this back when the location permission is missing — hashing it
+        // would invent one phantom access point shared by every unpermitted device.
+        assertNull(ApIdentifier.from("02:00:00:00:00:00"))
+        assertNull(ApIdentifier.from("00:00:00:00:00:00"))
+        assertNull(ApIdentifier.from("ff:ff:ff:ff:ff:ff"))
+    }
+
+    @Test
+    fun `malformed input returns null instead of a bogus identifier`() {
+        assertNull(ApIdentifier.from(null))
+        assertNull(ApIdentifier.from(""))
+        assertNull(ApIdentifier.from("b8:1e:61:00:95"))        // 5 octets
+        assertNull(ApIdentifier.from("b8:1e:61:00:95:0e:aa"))  // 7 octets
+        assertNull(ApIdentifier.from("zz:1e:61:00:95:0e"))     // not hex
+        assertNull(ApIdentifier.from("b81e6100950e"))          // no separators
+    }
+}


### PR DESCRIPTION
Reporta, junto de cada avistamento de beacon, os access points Wi-Fi visíveis e a última localização conhecida — para melhorar a precisão de posicionamento onde não há beacon por perto.

## Payload

Dois blocos novos no topo do envelope (ao lado de `beacons`) e campos em `device.network`:

```json
{
  "wifis": [
    { "apId": "…", "connected": true, "timestamp": 0, "rssi": -45, "frequencyMhz": 5260, "ssid": "…" }
  ],
  "location": {
    "latitude": 0, "longitude": 0, "timestamp": 0,
    "source": "gps", "accuracy": 12.4, "altitude": 780.2, "isMocked": false
  }
}
```

Blocos ausentes quando não há dado: um host sem as permissões manda exatamente o payload de antes.

| Campo | Observação |
|---|---|
| `apId` | Hash SHA-256 canônico do BSSID (16 hex) — a identidade que o backend usa |
| `ssid` / `network.wifiSSID` | Nome da rede. **Transitório**, para validar a coleta; marcados no código para remoção |
| `location.timestamp` | Do **fix**, não do envio — um fix pode ter minutos |

## `apId`: por que canonicalizar

iOS entrega o BSSID **sem** zeros à esquerda e o Android **com**. Hasheando cru, o mesmo roteador produziria dois identificadores distintos. Canônico: octetos com 2 dígitos, minúsculo, sem separador, SHA-256, 16 primeiros hex. Testes espelhados nos dois SDKs fixam o contrato, incluindo a rejeição dos BSSIDs-placeholder que as plataformas devolvem sem permissão.

## Privacidade

- Redes com SSID terminado em `_nomap` (convenção de opt-out honrada por Google e Mozilla) são descartadas no device.
- Placeholders de BSSID são rejeitados em vez de hasheados.

## Permissões

`ACCESS_WIFI_STATE` (já existia) e `NEARBY_WIFI_DEVICES` (nova, alternativa a location no Android 13+). Nada obrigatório: sem elas o SDK reporta apenas o AP conectado, ou nada. O SDK nunca pede permissão ao usuário.

Não declara `CHANGE_WIFI_STATE`: lê o **cache** de scan do sistema, nunca chama `startScan()`. A localização é sempre a **última conhecida**, nunca um fix ativo.

## Validação

`:sdk:assembleRelease` · testes do `ApIdentifier` — verdes.