### PR TITLE
docs: como habilitar as observações de Wi-Fi

### DIFF
--- a/AI-AGENT-SETUP.md
+++ b/AI-AGENT-SETUP.md
@@ -26,8 +26,8 @@ below refine it).
 2. Permissions: the SDK's manifest merge already injects every permission it needs
    (BLUETOOTH_SCAN with neverForLocation, ACCESS_FINE_LOCATION + ACCESS_COARSE_LOCATION,
    FOREGROUND_SERVICE, FOREGROUND_SERVICE_CONNECTED_DEVICE, POST_NOTIFICATIONS, INTERNET,
-   RECEIVE_BOOT_COMPLETED). Do NOT re-declare them, and do NOT add or request
-   ACCESS_BACKGROUND_LOCATION — background detection on Android 12+ runs on
+   RECEIVE_BOOT_COMPLETED, ACCESS_WIFI_STATE, NEARBY_WIFI_DEVICES). Do NOT re-declare
+   them, and do NOT add or request ACCESS_BACKGROUND_LOCATION — background detection on Android 12+ runs on
    BLUETOOTH_SCAN, and requesting it drags the app into Google Play's background-location
    review for zero benefit.
    AUDIT THE MERGED MANIFEST: this is an APPLICATION module on AGP 8.6+, so the task is
@@ -50,7 +50,9 @@ below refine it).
    `configure(businessToken = <ASK ME FOR IT>)`, then request the runtime permissions
    with an ActivityResultContracts.RequestMultiplePermissions launcher — BLUETOOTH_SCAN
    on Android 12+ (S+), ACCESS_FINE_LOCATION + ACCESS_COARSE_LOCATION on all versions,
-   POST_NOTIFICATIONS on Android 13+ — and call `startScanning()` once the scan gate is
+   POST_NOTIFICATIONS and NEARBY_WIFI_DEVICES on Android 13+ (NEARBY_WIFI_DEVICES rides
+   in the same "Nearby devices" dialog as BLUETOOTH_SCAN, so it costs no extra prompt and
+   it is what unlocks the Wi-Fi observations on 13+) — and call `startScanning()` once the scan gate is
    granted (BLUETOOTH_SCAN on 12+, ACCESS_FINE_LOCATION on <= 11). If the scan
    permission is denied, show a rationale and re-request — do not silently skip
    startScanning(). Implement onBeaconsUpdated, onError, and onSyncCompleted on the

--- a/README.md
+++ b/README.md
@@ -279,14 +279,39 @@ on iOS.
 Each payload also carries the device's **last known** location as context — the SDK never
 requests an active fix, so there is no extra GPS wake-up and no battery cost.
 
-**It is entirely opt-in, and the SDK never prompts.** Collection happens only if your app
-already holds the permissions:
+#### Turning it on
 
-| Your app grants | What the SDK reports |
+**The SDK never prompts** — it only reads what your app already has. What you report depends
+on which permissions the user granted:
+
+| Your app holds | What the SDK reports |
 |---|---|
 | Nothing | No `wifis[]` at all — payload identical to before |
-| `ACCESS_WIFI_STATE` only | The connected access point |
+| `ACCESS_WIFI_STATE` (automatic, no prompt) | The connected access point |
 | Location **or** `NEARBY_WIFI_DEVICES` (13+) | The connected access point **and** its neighbours |
+
+If you followed the [Quick Start](#quick-start), **you are already at the last row on Android
+≤ 12** — it requests location, which is what unlocks the neighbours there. To cover Android
+13+ as well, add one line to the same request:
+
+```kotlin
+if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+    add(Manifest.permission.NEARBY_WIFI_DEVICES)
+}
+```
+
+`NEARBY_WIFI_DEVICES` lives in the same **"Nearby devices"** permission group as
+`BLUETOOTH_SCAN`, so requesting both together shows the user a single dialog — the setup
+that maximises the data costs no extra prompt.
+
+Two things worth knowing before you ship it:
+
+- **Nothing degrades if you skip it.** Detection, background behaviour and every other field
+  are unaffected; you simply report fewer access points.
+- **Google Play Data Safety:** the Quick Start already declares **Location**, and Wi-Fi
+  observations do not add a new data type to that form — the access point identity travels
+  hashed. If you enable the transitional `ssid` fields, network names do leave the device,
+  which is worth reflecting in your own privacy policy.
 
 Two privacy behaviours are built in: networks whose name ends in `_nomap` (the opt-out
 convention honoured by Google and Mozilla) are dropped on the device, and placeholder
@@ -387,6 +412,10 @@ class MainActivity : ComponentActivity(), BeAroundSDKListener {
                 // Android 13+: without this the (optional) foreground-service
                 // notification is silently invisible.
                 add(Manifest.permission.POST_NOTIFICATIONS)
+                // Android 13+: unlocks the neighbouring access points for Wi-Fi
+                // observations. Same "Nearby devices" dialog as BLUETOOTH_SCAN, so
+                // asking for it adds no extra prompt for the user.
+                add(Manifest.permission.NEARBY_WIFI_DEVICES)
             }
         }
         permissionLauncher.launch(permissions.toTypedArray())


### PR DESCRIPTION
O SDK nunca pede permissão por conta própria. Sem instruções no README, o app integrador fica limitado ao access point conectado no Android 13+ — e nada quebra, então ninguém percebe.

- **Quick Start** passa a pedir `NEARBY_WIFI_DEVICES` no 13+.
- **Seção nova** com a tabela do que cada permissão libera, e o ponto que dispensa a objeção óbvia: `NEARBY_WIFI_DEVICES` está no mesmo grupo **"Nearby devices"** do `BLUETOOTH_SCAN`, então pedir os dois juntos mostra **um diálogo só**.
- Deixa explícito que quem seguiu o Quick Start **já tem os vizinhos no Android ≤ 12** (a location cobre lá), e que **nada degrada** se o integrador pular: detecção, background e o resto do payload seguem iguais.
- Nota de Data Safety: o `apId` viaja hasheado e não adiciona tipo de dado ao formulário; os campos `ssid` transitórios, sim, tiram nome de rede do aparelho.

`AI-AGENT-SETUP.md`: as permissões novas entram na lista do manifest merge e o `NEARBY_WIFI_DEVICES` no pedido de runtime.

Só documentação.