### PR TITLE
feat: coleta o Google Advertising ID (AAID)

### DIFF
--- a/AI-AGENT-SETUP.md
+++ b/AI-AGENT-SETUP.md
@@ -26,10 +26,21 @@ below refine it).
 2. Permissions: the SDK's manifest merge already injects every permission it needs
    (BLUETOOTH_SCAN with neverForLocation, ACCESS_FINE_LOCATION + ACCESS_COARSE_LOCATION,
    FOREGROUND_SERVICE, FOREGROUND_SERVICE_CONNECTED_DEVICE, POST_NOTIFICATIONS, INTERNET,
-   RECEIVE_BOOT_COMPLETED). Do NOT re-declare them, and do NOT add or request
-   ACCESS_BACKGROUND_LOCATION — background detection on Android 12+ runs on
+   RECEIVE_BOOT_COMPLETED, com.google.android.gms.permission.AD_ID). Do NOT re-declare
+   them, and do NOT add or request ACCESS_BACKGROUND_LOCATION — background detection on Android 12+ runs on
    BLUETOOTH_SCAN, and requesting it drags the app into Google Play's background-location
    review for zero benefit.
+   ADVERTISING ID (AD_ID): the SDK reports the Google Advertising ID when the host app
+   bundles Play Services — add
+   `implementation("com.google.android.gms:play-services-ads-identifier:18.2.0")` to the
+   app module if it is not already there (the SDK keeps it compileOnly, so without it the
+   id is simply absent and nothing else changes). There is NO runtime prompt on Android:
+   the user's choice lives in system settings and the platform enforces it. Declaring
+   AD_ID obliges the app to tick "Device or other IDs" in the Play Data Safety form — TELL
+   ME so I can update it. If this app targets children (Play Families policy forbids
+   AD_ID), strip it in the app manifest with
+   `<uses-permission android:name="com.google.android.gms.permission.AD_ID"
+   tools:node="remove" />` and skip the dependency.
    AUDIT THE MERGED MANIFEST: this is an APPLICATION module on AGP 8.6+, so the task is
    `./gradlew :app:processDebugMainManifest` (NOT processDebugManifest — that is a
    library-module task). Inspect the merged output at

--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ see the [AI setup prompt](./AI-AGENT-SETUP.md), step 2).
 | `FOREGROUND_SERVICE`, `FOREGROUND_SERVICE_CONNECTED_DEVICE` | Optional foreground service (see [Google Play review](#google-play-review--what-the-manifest-merge-means-for-your-app)) |
 | `ACCESS_WIFI_STATE` | Read the connected access point and the system's cached scan results (install-time, no prompt) |
 | `NEARBY_WIFI_DEVICES` | Alternative to location for reading neighbouring access points on Android 13+ — see [Wi-Fi observations](#wi-fi-observations) |
+| `com.google.android.gms.permission.AD_ID` | Google Advertising ID — see [Advertising identifier](#advertising-identifier-aaid) |
 
 `CHANGE_WIFI_STATE` is **not** declared: the SDK reads the system's cached scan results and
 never triggers a scan of its own.
@@ -294,6 +295,42 @@ addresses that Android returns when a permission is missing are discarded rather
 
 > **Migration note:** `network.apId` joins `network.wifiSSID` and is the field consumers
 > should read — a stable identity that survives the SSID being dropped later.
+
+### Advertising identifier (AAID)
+
+The SDK reports the **Google Advertising ID** — the resettable identifier that lets the same
+person be recognised across apps for advertising. It is what makes audiences built from
+beacon visits usable in ad platforms.
+
+**There is no runtime prompt on Android.** The user's choice lives in system settings, and
+the platform enforces it: opting out of ad personalisation turns the id into zeros, and the
+SDK reports none. The `AD_ID` permission is a *normal* permission — granted at install, no
+dialog — but required from `targetSdk` 33+, otherwise the platform zeroes the id even for
+users who allow it.
+
+To actually receive an id, your app needs Google Play Services on the classpath:
+
+```gradle
+implementation 'com.google.android.gms:play-services-ads-identifier:18.2.0'
+```
+
+The SDK keeps this dependency `compileOnly` — the same soft-dependency pattern it uses for
+Firebase — so **nothing is forced on you**. Apps that already bundle Play Services (most apps
+with FCM already do) get the id automatically; apps that don't simply report none, and every
+other feature works the same.
+
+The payload carries `device.permissions.advertisingId` when available, plus `limitAdTracking`
+— so a user opt-out is distinguishable from Play Services being absent.
+
+> **Google Play Data Safety:** declaring `AD_ID` means ticking **"Device or other IDs"** in
+> your Data Safety form.
+>
+> **Apps for children:** Play Families policy forbids `AD_ID`. Strip it from the merged
+> manifest and the SDK degrades to reporting no id:
+> ```xml
+> <uses-permission android:name="com.google.android.gms.permission.AD_ID"
+>     tools:node="remove" />
+> ```
 
 ### Permission model: `neverForLocation` and location
 

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -143,4 +143,9 @@ dependencies {
     // Firebase Cloud Messaging — soft dependency (compileOnly, not bundled). See tryAutoCollectFcmToken.
     compileOnly 'com.google.firebase:firebase-messaging:24.0.0'
     compileOnly 'com.google.firebase:firebase-common:21.0.0'
+
+    // Google Advertising ID — soft dependency (compileOnly, not bundled), same pattern as
+    // Firebase above. Hosts that bundle Play Services report the AAID; hosts that do not
+    // report none and nothing else changes. See AdvertisingIdCollector.
+    compileOnly 'com.google.android.gms:play-services-ads-identifier:18.2.0'
 }

--- a/sdk/src/main/AndroidManifest.xml
+++ b/sdk/src/main/AndroidManifest.xml
@@ -60,6 +60,15 @@
 
     <!-- Notifications permission (Android 13+) -->
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+
+    <!-- Google Advertising ID (AAID). Normal permission, granted at install with no user
+         prompt — but REQUIRED from targetSdk 33+: without it the platform hands back a
+         zeroed id even when the user allows ad personalisation.
+         The user's own choice still wins: opting out in system settings zeroes the id and
+         the SDK reports none. Declaring this obliges the host to tick "Device or other IDs"
+         in the Play Data Safety form; a host that must NOT collect it (apps for children)
+         can strip it with tools:node="remove" and the SDK degrades to reporting no id. -->
+    <uses-permission android:name="com.google.android.gms.permission.AD_ID" />
     
     <!-- Boot completed permission for restart scanning after reboot -->
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />

--- a/sdk/src/main/java/io/bearound/sdk/BeAroundSDK.kt
+++ b/sdk/src/main/java/io/bearound/sdk/BeAroundSDK.kt
@@ -621,6 +621,11 @@ class BeAroundSDK private constructor() {
 
         tryAutoCollectFcmToken(context)
 
+        // Advertising ID: fetched in the background because AdvertisingIdClient throws if
+        // called on the main thread. Lands in the cache before the first sync in practice;
+        // if it does not, the field is simply absent from that one payload.
+        io.bearound.sdk.utilities.AdvertisingIdCollector.refresh(context)
+
         // First-access contract: the device must appear in the backend as soon as the SDK
         // is configured — registration (with the push token, once available) must NOT
         // depend on the host also calling startScanning(). TTL-gated, so a no-op when

--- a/sdk/src/main/java/io/bearound/sdk/models/UserDevice.kt
+++ b/sdk/src/main/java/io/bearound/sdk/models/UserDevice.kt
@@ -56,6 +56,17 @@ data class UserDevice(
      * Last known fix, as context for [wifis] and for the beacons in the same payload.
      * Null when unavailable; the SDK never requests an active fix.
      */
-    val location: DeviceLocation? = null
+    val location: DeviceLocation? = null,
+    /**
+     * Google Advertising ID (AAID) — resettable, user-controlled identifier for advertising.
+     * Null when the user opted out, when Play Services is absent, or before the first
+     * async fetch lands.
+     */
+    val advertisingId: String? = null,
+    /**
+     * True when the user asked apps not to track them. Reported alongside [advertisingId]
+     * so an opt-out is distinguishable from Play Services simply being unavailable.
+     */
+    val limitAdTracking: Boolean? = null
 )
 

--- a/sdk/src/main/java/io/bearound/sdk/network/APIClient.kt
+++ b/sdk/src/main/java/io/bearound/sdk/network/APIClient.kt
@@ -322,6 +322,11 @@ class APIClient(private val configuration: SDKConfiguration) {
             put("notifications", device.notificationsPermission)
             put("bluetooth", device.bluetoothState)
             device.locationAccuracy?.let { put("locationAccuracy", it) }
+            // Advertising ID lives here because that is where the ingest already reads it
+            // from (`device.permissions.advertisingId`) — it is provided by the SDK so the
+            // backend can skip the matchmaker round-trip.
+            device.advertisingId?.let { put("advertisingId", it) }
+            device.limitAdTracking?.let { put("limitAdTracking", it) }
         }
         payload.put("permissions", permissions)
 

--- a/sdk/src/main/java/io/bearound/sdk/utilities/AdvertisingIdCollector.kt
+++ b/sdk/src/main/java/io/bearound/sdk/utilities/AdvertisingIdCollector.kt
@@ -1,0 +1,82 @@
+package io.bearound.sdk.utilities
+
+import android.content.Context
+import android.util.Log
+import java.util.concurrent.atomic.AtomicReference
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+/**
+ * Reads the Google Advertising ID (AAID) — the resettable, user-controlled identifier that
+ * lets the same person be recognised across apps for advertising purposes.
+ *
+ * Three properties of the platform shape this implementation:
+ *
+ * 1. **No prompt exists.** Unlike iOS, Android has no dialog for the advertising ID. The
+ *    user's choice lives in system settings, and the platform enforces it for us: opting out
+ *    turns the ID into a zeroed UUID, which we treat as absent.
+ *
+ * 2. **It must not be read on the main thread.** `AdvertisingIdClient` throws if you try. So
+ *    the value is fetched once in the background and cached; payload building reads the
+ *    cache synchronously.
+ *
+ * 3. **Google Play Services is a soft dependency.** `play-services-ads-identifier` is
+ *    `compileOnly`, mirroring the Firebase pattern: apps that bundle Play Services get the
+ *    ID, apps that do not simply report none. No host is forced to take the dependency.
+ */
+internal object AdvertisingIdCollector {
+
+    private const val TAG = "AdvertisingId"
+
+    /** Returned by the platform when the user opted out of ad personalisation. */
+    private const val OPTED_OUT = "00000000-0000-0000-0000-000000000000"
+
+    private val cached = AtomicReference<String?>(null)
+    private val limitTracking = AtomicReference<Boolean?>(null)
+
+    /**
+     * Fetches the advertising ID in the background and caches it. Safe to call repeatedly —
+     * a refresh is cheap and the user can reset the ID at any time.
+     */
+    fun refresh(context: Context) {
+        CoroutineScope(Dispatchers.IO).launch {
+            try {
+                val info = com.google.android.gms.ads.identifier.AdvertisingIdClient
+                    .getAdvertisingIdInfo(context.applicationContext)
+
+                val id = info.id
+                val limited = info.isLimitAdTrackingEnabled
+                limitTracking.set(limited)
+
+                cached.set(
+                    when {
+                        limited -> null
+                        id.isNullOrBlank() -> null
+                        id == OPTED_OUT -> null
+                        else -> id
+                    }
+                )
+            } catch (t: Throwable) {
+                // NoClassDefFoundError when Play Services is not bundled; GooglePlayServices*
+                // exceptions when it is present but unavailable on the device. Both mean the
+                // same thing to us: no advertising ID, and nothing else changes.
+                Log.d(TAG, "advertising ID unavailable: ${t.javaClass.simpleName}")
+                cached.set(null)
+            }
+        }
+    }
+
+    /**
+     * @return the cached advertising ID, or `null` when the user opted out, Play Services is
+     *         absent, or the first fetch has not landed yet.
+     */
+    fun current(): String? = cached.get()
+
+    /**
+     * @return true when the user asked apps not to track them, false when they allow it, and
+     *         `null` while unknown. Reported separately from the ID so the backend can tell
+     *         "opted out" apart from "Play Services missing".
+     */
+    fun isLimitAdTrackingEnabled(): Boolean? = limitTracking.get()
+}

--- a/sdk/src/main/java/io/bearound/sdk/utilities/DeviceInfoCollector.kt
+++ b/sdk/src/main/java/io/bearound/sdk/utilities/DeviceInfoCollector.kt
@@ -87,7 +87,9 @@ class DeviceInfoCollector(
             systemUptimeMs = SystemClock.elapsedRealtime(),
             sdkVersion = Build.VERSION.SDK_INT,
             wifis = wifis,
-            location = locationCollector.lastKnown()
+            location = locationCollector.lastKnown(),
+            advertisingId = AdvertisingIdCollector.current(),
+            limitAdTracking = AdvertisingIdCollector.isLimitAdTrackingEnabled()
         )
     }
 


### PR DESCRIPTION
Reporta o **Google Advertising ID** (AAID) em `device.permissions.advertisingId`, junto de `limitAdTracking` — que distingue "usuário optou por sair" de "Play Services indisponível".

## Implementação

**Não existe prompt no Android.** A escolha do usuário vive nos ajustes do sistema e a plataforma a impõe: quem opta por sair recebe um UUID zerado, tratado como ausente.

Duas decisões que valem o review:

- **`play-services-ads-identifier` é `compileOnly`** — mesmo padrão de soft dependency já usado para o Firebase neste SDK. Apps que bundlam Play Services recebem o id; os demais reportam nenhum e nada mais muda. Nenhum host é obrigado a pegar a dependência.
- **A busca roda em background.** `AdvertisingIdClient` lança se chamado na main thread, então o id é buscado uma vez no `configure()` e cacheado; a montagem do payload lê o cache.

## Permissão

`com.google.android.gms.permission.AD_ID` — normal, concedida na instalação, sem diálogo. Obrigatória a partir do `targetSdk` 33: sem ela o sistema zera o id mesmo para usuários que permitem.

Impactos para o app integrador, documentados no README:

- **Data Safety**: declarar `AD_ID` obriga a marcar "Device or other IDs".
- **Apps para crianças**: a política Play Families proíbe `AD_ID` — dá para removê-lo do manifest mesclado com `tools:node="remove"`, e o SDK degrada para não reportar id.

## Validação

`:sdk:assembleRelease` · `:sdk:testDebugUnitTest` · `:sdk:lintDebug` — todos BUILD SUCCESSFUL.