### PR TITLE
feat: scan sem beacon reporta localização e Wi-Fi (presence heartbeat)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to the BeAround Android SDK will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **A scan that finds nothing now reports in too.** Until now a device that saw no beacon
+  and no peer stayed silent, and the backend could not tell "there was no coverage here"
+  apart from "the app was not running". Those scans now upload the device's own location
+  and the Wi-Fi around it. Throttled by the new `configure(presenceHeartbeatIntervalMillis:)`
+  — **5 minutes** by default, accepted range 1 minute to 1 hour, `0` to turn the report off.
+  Only the upload is throttled; scanning is unchanged. Nothing is sent when there is neither
+  a location fix nor an access point to report. Requires an ingest that accepts this payload
+  shape (beacon-ingest ≥ #24).
+
 ## [3.7.1] - 2026-08-01
 
 ### Fixed

--- a/sdk/src/main/java/io/bearound/sdk/BeAroundSDK.kt
+++ b/sdk/src/main/java/io/bearound/sdk/BeAroundSDK.kt
@@ -27,6 +27,7 @@ import io.bearound.sdk.models.BeaconMetadata
 import io.bearound.sdk.models.ForegroundScanConfig
 import io.bearound.sdk.models.MaxQueuedPayloads
 import io.bearound.sdk.models.PeriodicReconciliationDefaults
+import io.bearound.sdk.models.PresenceHeartbeatDefaults
 import io.bearound.sdk.models.SDKConfiguration
 import io.bearound.sdk.models.SDKInfo
 import io.bearound.sdk.models.ScanPrecision
@@ -572,7 +573,8 @@ class BeAroundSDK private constructor() {
         technology: String = "android-native",
         periodicReconciliationEnabled: Boolean = true,
         periodicReconciliationIntervalMillis: Long = PeriodicReconciliationDefaults.DEFAULT_INTERVAL_MILLIS,
-        periodicScanDurationMillis: Long = PeriodicReconciliationDefaults.DEFAULT_SCAN_DURATION_MILLIS
+        periodicScanDurationMillis: Long = PeriodicReconciliationDefaults.DEFAULT_SCAN_DURATION_MILLIS,
+        presenceHeartbeatIntervalMillis: Long = PresenceHeartbeatDefaults.DEFAULT_INTERVAL_MILLIS
     ): BeAroundSDK {
         // NEVER-CRASH-THE-HOST: an embedded SDK must not throw from a public entry
         // point — a host wired to an empty BuildConfig field would crash on startup.
@@ -598,7 +600,9 @@ class BeAroundSDK private constructor() {
             periodicReconciliationIntervalMillis =
                 PeriodicReconciliationDefaults.sanitizedInterval(periodicReconciliationIntervalMillis),
             periodicScanDurationMillis =
-                PeriodicReconciliationDefaults.sanitizedScanDuration(periodicScanDurationMillis)
+                PeriodicReconciliationDefaults.sanitizedScanDuration(periodicScanDurationMillis),
+            presenceHeartbeatIntervalMillis =
+                PresenceHeartbeatDefaults.sanitizedInterval(presenceHeartbeatIntervalMillis)
         )
 
         configuration = config
@@ -1348,6 +1352,35 @@ class BeAroundSDK private constructor() {
         return true
     }
 
+    /** Timestamp of the last empty-scan report, for the throttle in [shouldReportEmptyScan]. */
+    @Volatile private var lastPresenceHeartbeatAt = 0L
+
+    /**
+     * True when a scan that found nothing should still report in.
+     *
+     * The scan found no beacon and no peer — but the device has its own location, or the
+     * Wi-Fi around it, and *that* is the datum: it was here, and there was nothing here.
+     * Without this the backend cannot tell "no coverage" apart from "app not running".
+     *
+     * Throttled by [SDKConfiguration.presenceHeartbeatIntervalMillis] (5 min by default, `0`
+     * disables it) so a phone sitting still overnight does not repeat one coordinate every
+     * minute. Only the upload is throttled — scanning never stops. Advances the timestamp on
+     * approval, mirroring [shouldSyncEncountersWithoutBeacons].
+     */
+    private fun shouldReportEmptyScan(): Boolean {
+        val interval = configuration?.presenceHeartbeatIntervalMillis
+            ?: PresenceHeartbeatDefaults.DEFAULT_INTERVAL_MILLIS
+        if (interval <= 0L) return false
+        val now = System.currentTimeMillis()
+        if (now - lastPresenceHeartbeatAt < interval) return false
+        // Nothing to say: no fix and no access point. Reporting an empty shell would cost a
+        // request and teach the backend nothing.
+        if (!deviceInfoCollector.hasPresenceSignal()) return false
+        lastPresenceHeartbeatAt = now
+        Log.d(TAG, "No beacons or peers — reporting empty scan (location/Wi-Fi)")
+        return true
+    }
+
     private fun syncBeacons(forceBackground: Boolean = false) {
         scope.launch { syncBeaconsAwait(forceBackground) }
     }
@@ -1396,10 +1429,17 @@ class BeAroundSDK private constructor() {
                 collectedBeacons.values.filter { !it.alreadySynced }
             }
 
-            // Encounter mesh: sightings must reach the backend even when no physical
-            // beacon is around — otherwise a device that only sees other devices never
-            // uploads anything. Throttled (60s) and gated on fresh identified sightings.
-            if (rawBeaconsToSend.isEmpty() && !shouldSyncEncountersWithoutBeacons()) return true
+            // Two reasons to upload with no beacon in hand:
+            //  - encounter mesh: the device saw other devices (throttled 60s, gated on fresh
+            //    identified sightings) — otherwise a device that only sees peers never uploads;
+            //  - empty scan: it saw nothing at all, and where it was plus the Wi-Fi around it
+            //    is the datum (throttled by presenceHeartbeatIntervalMillis).
+            if (rawBeaconsToSend.isEmpty() &&
+                !shouldSyncEncountersWithoutBeacons() &&
+                !shouldReportEmptyScan()
+            ) {
+                return true
+            }
 
             // Snapshot + reset per-beacon RSSI accumulators so the payload carries the
             // FULL window stats and the next window starts fresh.

--- a/sdk/src/main/java/io/bearound/sdk/models/SDKConfiguration.kt
+++ b/sdk/src/main/java/io/bearound/sdk/models/SDKConfiguration.kt
@@ -17,6 +17,43 @@ import android.util.Log
  * - **Scan window (3–30 s)**: bounded so a misconfigured window can neither miss the
  *   advertising cadence (< 3 s) nor camp on the radio (> 30 s).
  */
+/**
+ * Defaults and bounds for the empty-scan report (see
+ * [SDKConfiguration.presenceHeartbeatIntervalMillis]).
+ */
+object PresenceHeartbeatDefaults {
+    private const val TAG = "BeAroundSDK-Config"
+
+    /** Default floor between two consecutive "saw nothing" reports. */
+    const val DEFAULT_INTERVAL_MILLIS: Long = 5L * 60L * 1000L
+    /**
+     * Interval floor. Below a minute the same coordinate is repeated for no added meaning,
+     * and every report wakes the radio.
+     */
+    const val MINIMUM_INTERVAL_MILLIS: Long = 60L * 1000L
+    /** Interval ceiling. Past an hour the trail is too sparse to say anything about presence. */
+    const val MAXIMUM_INTERVAL_MILLIS: Long = 60L * 60L * 1000L
+
+    /**
+     * Sanitizes a host-provided interval. Non-positive means "off" and is returned as `0`
+     * (that is the documented way to disable the report); out-of-range values are clamped
+     * with an ERROR-level log — never a silent change, never a crash.
+     */
+    fun sanitizedInterval(value: Long): Long {
+        // Explicit opt-out — not an error, and not clamped into the accepted range.
+        if (value <= 0L) return 0L
+        if (value < MINIMUM_INTERVAL_MILLIS) {
+            Log.e(TAG, "⚠️ presenceHeartbeatIntervalMillis ${value}ms is below the ${MINIMUM_INTERVAL_MILLIS / 1000}s floor — CLAMPED. A still device would repeat the same coordinate every few seconds, waking the radio each time, and the extra points say nothing new.")
+            return MINIMUM_INTERVAL_MILLIS
+        }
+        if (value > MAXIMUM_INTERVAL_MILLIS) {
+            Log.e(TAG, "⚠️ presenceHeartbeatIntervalMillis ${value}ms is above the 1h ceiling — CLAMPED. To turn the empty-scan report off, pass 0 instead.")
+            return MAXIMUM_INTERVAL_MILLIS
+        }
+        return value
+    }
+}
+
 object PeriodicReconciliationDefaults {
     private const val TAG = "BeAroundSDK-Config"
 
@@ -97,7 +134,23 @@ data class SDKConfiguration(
      * **3–30 seconds**. Only used while waiting for the continuous scanners to deliver;
      * the worker never registers scanners of its own.
      */
-    val periodicScanDurationMillis: Long = PeriodicReconciliationDefaults.DEFAULT_SCAN_DURATION_MILLIS
+    val periodicScanDurationMillis: Long = PeriodicReconciliationDefaults.DEFAULT_SCAN_DURATION_MILLIS,
+    /**
+     * How often a scan that found **nothing** still reports in.
+     *
+     * A scan that finds no beacon and no peer is data too: the device was *here* and saw
+     * nothing. Those payloads carry the device's own location and the Wi-Fi it can see, and
+     * they are what make coverage — and the absence of it — visible.
+     *
+     * Only the *upload* is throttled, never the scan: a beacon or an encounter still syncs at
+     * the normal cadence. This is the floor between two consecutive "saw nothing" reports, so
+     * a phone sitting still all night does not repeat the same coordinate every minute.
+     *
+     * Accepted range: **1 minute … 1 hour**; out-of-range values are clamped with an
+     * ERROR-level log. Use **0** to turn the empty-scan report off entirely. Sanitize via
+     * [PresenceHeartbeatDefaults.sanitizedInterval] before constructing directly.
+     */
+    val presenceHeartbeatIntervalMillis: Long = PresenceHeartbeatDefaults.DEFAULT_INTERVAL_MILLIS
 ) {
     val apiBaseURL: String = "https://ingest.bearound.io"
 

--- a/sdk/src/main/java/io/bearound/sdk/network/APIClient.kt
+++ b/sdk/src/main/java/io/bearound/sdk/network/APIClient.kt
@@ -105,7 +105,16 @@ class APIClient(private val configuration: SDKConfiguration) {
         userProperties: UserProperties?,
         onComplete: (Result<Unit>) -> Unit
     ) {
-        if (beacons.isEmpty() && userDevice.encounters.isEmpty()) {
+        // Nothing at all to report — not a beacon, not a peer, not even where the device is.
+        // An empty shell would cost a request and teach the backend nothing. Whether a scan
+        // that found nothing is worth uploading is decided upstream, by the heartbeat
+        // throttle (BeAroundSDK.shouldReportEmptyScan); by the time it reaches here, the
+        // location/Wi-Fi it carries IS the payload.
+        if (beacons.isEmpty() &&
+            userDevice.encounters.isEmpty() &&
+            userDevice.location == null &&
+            userDevice.wifis.isEmpty()
+        ) {
             onComplete(Result.success(Unit))
             return
         }

--- a/sdk/src/main/java/io/bearound/sdk/utilities/DeviceInfoCollector.kt
+++ b/sdk/src/main/java/io/bearound/sdk/utilities/DeviceInfoCollector.kt
@@ -33,6 +33,16 @@ class DeviceInfoCollector(
     internal fun nudgeWifiScan() = wifiCollector.nudgeScan()
     private val locationCollector by lazy { LocationCollector(context) }
 
+    /**
+     * Is there anything worth reporting when the scan found no beacon and no peer?
+     *
+     * Cheap on purpose: the empty-scan decision runs on every sync tick, and building a whole
+     * [UserDevice] just to find out there is nothing to say would be the expensive way to
+     * answer it. Reads the same two sources the payload would carry.
+     */
+    internal fun hasPresenceSignal(): Boolean =
+        locationCollector.lastKnown() != null || wifiCollector.collect().isNotEmpty()
+
     companion object {
         /**
          * True only for the FIRST payload each process builds. The old constructor flag


### PR DESCRIPTION
 ## O que muda

Um scan que **não acha nada** também é dado: o aparelho estava ali e não viu beacon nem par. Até agora ele ficava calado, e o backend não distinguia *"não há cobertura aqui"* de *"o app não estava rodando"*.

Esses scans passam a subir **a localização do próprio aparelho + o Wi-Fi ao redor**