### PR TITLE
fix: stamp why a beacon-less payload is going up

### DIFF
--- a/sdk/src/main/java/io/bearound/sdk/BeAroundSDK.kt
+++ b/sdk/src/main/java/io/bearound/sdk/BeAroundSDK.kt
@@ -1434,11 +1434,17 @@ class BeAroundSDK private constructor() {
             //    identified sightings) — otherwise a device that only sees peers never uploads;
             //  - empty scan: it saw nothing at all, and where it was plus the Wi-Fi around it
             //    is the datum (throttled by presenceHeartbeatIntervalMillis).
-            if (rawBeaconsToSend.isEmpty() &&
-                !shouldSyncEncountersWithoutBeacons() &&
-                !shouldReportEmptyScan()
-            ) {
-                return true
+            // Why this payload is going up, when it is not simply "beacons were seen".
+            // Without stamping it, an encounter batch and an empty-scan report reach the
+            // backend looking exactly like an ordinary sync with nothing in it — which is
+            // precisely the distinction this release exists to make.
+            var syncTrigger: String? = null
+            if (rawBeaconsToSend.isEmpty()) {
+                syncTrigger = when {
+                    shouldSyncEncountersWithoutBeacons() -> "encounter_mesh"
+                    shouldReportEmptyScan() -> "presence_heartbeat"
+                    else -> return true
+                }
             }
 
             // Snapshot + reset per-beacon RSSI accumulators so the payload carries the
@@ -1481,7 +1487,7 @@ class BeAroundSDK private constructor() {
             // sendBeacons is suspend and invokes the callback before returning,
             // so syncOk is settled by the time we return it.
             var syncOk = false
-            client.sendBeacons(beaconsToSend, info, userDevice, userProperties) { result ->
+            client.sendBeacons(beaconsToSend, info, userDevice, userProperties, syncTrigger) { result ->
                 result.fold(
                     onSuccess = {
                         syncOk = true

--- a/sdk/src/main/java/io/bearound/sdk/network/APIClient.kt
+++ b/sdk/src/main/java/io/bearound/sdk/network/APIClient.kt
@@ -64,8 +64,7 @@ class APIClient(private val configuration: SDKConfiguration) {
                 connection.doOutput = true
 
                 // beacons=[] + syncTrigger="register" (iOS parity)
-                val payload = buildPayload(emptyList(), sdkInfo, userDevice, userProperties)
-                payload.put("syncTrigger", "register")
+                val payload = buildPayload(emptyList(), sdkInfo, userDevice, userProperties, "register")
 
                 Log.d(TAG, "Sending register event to $url")
 
@@ -103,6 +102,14 @@ class APIClient(private val configuration: SDKConfiguration) {
         sdkInfo: SDKInfo,
         userDevice: UserDevice,
         userProperties: UserProperties?,
+        /**
+         * Why this payload is going up, when that is not simply "beacons were seen":
+         * `encounter_mesh` (only peers around) or `presence_heartbeat` (nothing at all, so
+         * the location and Wi-Fi ARE the datum). Omitted for an ordinary beacon sync, which
+         * needs no explanation. Without it the backend cannot tell a presence report from a
+         * normal sync — both arrive as a payload with an empty beacon list.
+         */
+        syncTrigger: String? = null,
         onComplete: (Result<Unit>) -> Unit
     ) {
         // Nothing at all to report — not a beacon, not a peer, not even where the device is.
@@ -132,7 +139,7 @@ class APIClient(private val configuration: SDKConfiguration) {
                 connection.doOutput = true
 
                 // Build JSON payload
-                val payload = buildPayload(beacons, sdkInfo, userDevice, userProperties)
+                val payload = buildPayload(beacons, sdkInfo, userDevice, userProperties, syncTrigger)
 
                 // Send request
                 Log.d(TAG, "Sending ${beacons.size} beacon(s) to $url")
@@ -176,7 +183,8 @@ class APIClient(private val configuration: SDKConfiguration) {
         beacons: List<Beacon>,
         sdkInfo: SDKInfo,
         userDevice: UserDevice,
-        userProperties: UserProperties?
+        userProperties: UserProperties?,
+        syncTrigger: String? = null
     ): JSONObject {
         val payload = JSONObject()
 
@@ -224,6 +232,7 @@ class APIClient(private val configuration: SDKConfiguration) {
             beaconsArray.put(beaconObj)
         }
         payload.put("beacons", beaconsArray)
+        syncTrigger?.let { payload.put("syncTrigger", it) }
 
         // SDK info
         val sdkObj = JSONObject().apply {


### PR DESCRIPTION
Android never labelled the two upload paths 3.8.0 introduced.

## The gap

`syncTrigger` was only ever written on the register path:

```kotlin
payload.put("syncTrigger", "register")   // the only occurrence
```

So an **encounter batch** (peers around, no beacon) and an **empty-scan report** (nothing
around, location + Wi-Fi are the datum) both reached `/ingest` with **no trigger at all** —
indistinguishable from an ordinary sync that happened to carry nothing. Telling those apart
is the reason the field exists.

Confirmed in the archive: Android payloads from 3.8.0 arrive with no `syncTrigger`, while
iOS stamps `encounter_mesh` / `presence_heartbeat`.

## The fix

`sendBeacons` takes the reason and `buildPayload` writes it, so the register path stops
setting the field by hand — one place where `syncTrigger` reaches the wire instead of two.
The decision mirrors the iOS branch order: `encounter_mesh` wins over `presence_heartbeat`,
and an ordinary beacon sync sends no trigger.

No contract change (the field was already accepted), no new permission, no version bump
here. `./gradlew :sdk:testDebugUnitTest :sdk:lintDebug` passes.