### PR TITLE
bump: version 3.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to the BeAround Android SDK will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.8.1] - 2026-08-04
+
+### Fixed
+- **A beacon-less payload never said why it was going up.** `syncTrigger` was only ever set
+  on the register path, so an encounter batch (peers around, no beacon) and an empty-scan
+  report (nothing around — the location and Wi-Fi ARE the datum) both reached `/ingest` with
+  no trigger at all, indistinguishable from an ordinary sync that happened to carry nothing.
+  Telling those apart is the reason the field exists. Both are now stamped, matching iOS.
+
 ## [3.8.0] - 2026-08-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -149,14 +149,14 @@ allprojects {
 ```kotlin
 // build.gradle.kts
 dependencies {
-    implementation("com.github.Bearound:bearound-android-sdk:3.8.0")
+    implementation("com.github.Bearound:bearound-android-sdk:3.8.1")
 }
 ```
 
 ```gradle
 // build.gradle
 dependencies {
-    implementation 'com.github.Bearound:bearound-android-sdk:3.8.0'
+    implementation 'com.github.Bearound:bearound-android-sdk:3.8.1'
 }
 ```
 
@@ -166,7 +166,7 @@ for how they wire together with one line):
 
 ```gradle
 dependencies {
-    implementation 'com.github.Bearound:bearound-android-sdk:3.8.0'
+    implementation 'com.github.Bearound:bearound-android-sdk:3.8.1'
     implementation 'com.github.Bearound:bearound-telemetry-android-sdk:v0.1.2'
 }
 ```

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,4 +10,4 @@ org.gradle.configureondemand=true
 # SDK Metadata
 SDK_GROUP_ID=com.github.Bearound
 SDK_ARTIFACT_ID=bearound-android-sdk
-SDK_VERSION=3.8.0
+SDK_VERSION=3.8.1


### PR DESCRIPTION
Release of the sync-trigger fix (#80). `SDK_VERSION`, CHANGELOG and the README install pin.