### PR TITLE
feat: reporta backgroundLocation e corrige a orientação de setup

### DIFF
--- a/AI-AGENT-SETUP.md
+++ b/AI-AGENT-SETUP.md
@@ -27,10 +27,21 @@ below refine it).
    (BLUETOOTH_SCAN with neverForLocation, ACCESS_FINE_LOCATION + ACCESS_COARSE_LOCATION,
    FOREGROUND_SERVICE, FOREGROUND_SERVICE_CONNECTED_DEVICE, POST_NOTIFICATIONS, INTERNET,
    RECEIVE_BOOT_COMPLETED, ACCESS_WIFI_STATE, NEARBY_WIFI_DEVICES,
-   com.google.android.gms.permission.AD_ID). Do NOT re-declare
-   them, and do NOT add or request ACCESS_BACKGROUND_LOCATION — background detection on Android 12+ runs on
-   BLUETOOTH_SCAN, and requesting it drags the app into Google Play's background-location
-   review for zero benefit.
+   com.google.android.gms.permission.AD_ID). Do NOT re-declare them.
+   ACCESS_BACKGROUND_LOCATION: do NOT add it on your own — but do NOT silently skip it
+   either. It is NOT needed for beacon detection (on Android 12+ that runs on
+   BLUETOOTH_SCAN, no location at all), and it costs a Google Play policy review plus a
+   demonstration video. BUT without it, from Android 10 on, Wi-Fi observations only work
+   while the app is in the FOREGROUND: a backgrounded app gets an empty scan list and the
+   placeholder BSSID 02:00:00:00:00:00 — no error, nothing in logcat, and `wifis[]` simply
+   arrives empty. Measured on a real device: 25 access points dropped to zero the instant
+   the app was backgrounded, with every permission it asked for granted. Since a fleet lives
+   in the background, "foreground only" means "almost never". So: ASK ME whether Wi-Fi
+   collection in the background matters for this app. If I say yes, add it to MY manifest
+   and request it as a SEPARATE, SECOND prompt after foreground location is already granted
+   (Android 11+ refuses to grant both in one dialog and sends the user to Settings). If I
+   say no, or if this app only detects beacons, leave it out — that is a valid choice, just
+   not a silent one.
    ADVERTISING ID (AD_ID): the SDK reports the Google Advertising ID when the host app
    bundles Play Services — add
    `implementation("com.google.android.gms:play-services-ads-identifier:18.2.0")` to the
@@ -165,7 +176,10 @@ Guardrails — follow strictly:
   and the device never appears in the Control Hub. Keep it that way.
 - Ask me for my businessToken; do not invent one, never hardcode/commit it, and never
   fall back to the BearoundScan public test token — the app/build.gradle fallback is "".
-- Do NOT request ACCESS_BACKGROUND_LOCATION.
+- Do NOT request ACCESS_BACKGROUND_LOCATION without asking me first — see step 2. It is
+  irrelevant to beacon detection and costs a Play review, but leaving it out silently caps
+  Wi-Fi collection to the foreground, which for a real fleet is close to collecting nothing.
+  Verify the outcome in the payload: `device.permissions.backgroundLocation`.
 - Default to plain startScanning() and strip FOREGROUND_SERVICE_CONNECTED_DEVICE
   (tools:node="remove"). Only wire the connectedDevice foreground service after asking me.
 - STOP and hand me click-by-click steps for anything only a human can do: the on-device

--- a/README.md
+++ b/README.md
@@ -295,6 +295,27 @@ on which permissions the user granted:
 | Nothing | No `wifis[]` at all — payload identical to before |
 | `ACCESS_WIFI_STATE` (automatic, no prompt) | The connected access point |
 | Location **or** `NEARBY_WIFI_DEVICES` (13+) | The connected access point **and** its neighbours |
+| …plus `ACCESS_BACKGROUND_LOCATION` | **The same, while your app is in the background** |
+
+> ### ⚠️ Without background location you collect Wi-Fi only in the foreground
+>
+> This is the single most surprising thing on this page, so it is worth being blunt about:
+> from **Android 10** on, a backgrounded app without `ACCESS_BACKGROUND_LOCATION` gets an
+> **empty scan list** and the placeholder BSSID `02:00:00:00:00:00` — not an error, not a
+> `SecurityException`, nothing in logcat. The SDK discards the placeholder (it must — every
+> device on earth returns the same one), so `wifis[]` and `network.apId` simply arrive
+> empty.
+>
+> Measured on a real device: the same app, same session, every permission it asked for
+> granted, went from **25 access points to zero** the instant it was backgrounded. Location
+> stopped coming through in the same payload.
+>
+> Since a fleet spends almost all of its time in the background, "foreground only" means
+> "almost never". If your integration tests by hand with the app open, it will look perfect.
+>
+> **Check it without guessing:** every payload reports
+> `device.permissions.backgroundLocation`. If it is `false`, you are collecting Wi-Fi in the
+> foreground only.
 
 If you followed the [Quick Start](#quick-start), **you are already at the last row on Android
 ≤ 12** — it requests location, which is what unlocks the neighbours there. To cover Android
@@ -310,14 +331,41 @@ if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
 `BLUETOOTH_SCAN`, so requesting both together shows the user a single dialog — the setup
 that maximises the data costs no extra prompt.
 
+#### Collecting in the background
+
+`ACCESS_BACKGROUND_LOCATION` is **not** declared by the SDK, on purpose: it is a dangerous
+permission with a Google Play policy review attached, and declaring it here would drag every
+host app through that review — including the ones that only detect beacons and never touch
+Wi-Fi. It has to be your decision.
+
+If you want it, declare it in **your** manifest and request it as a **separate, second**
+prompt — from Android 11 on the system refuses to grant it in the same dialog as foreground
+location, and sends the user to Settings to pick "Allow all the time":
+
+```kotlin
+// AndroidManifest.xml (yours, not the SDK's)
+<uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
+```
+
+```kotlin
+// Only AFTER foreground location has been granted, and never in the same request.
+if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+    requestPermissions(arrayOf(Manifest.permission.ACCESS_BACKGROUND_LOCATION), REQ)
+}
+```
+
 Two things worth knowing before you ship it:
 
-- **Nothing degrades if you skip it.** Detection, background behaviour and every other field
-  are unaffected; you simply report fewer access points.
+- **Beacon detection does not need it.** Detection, background wake-up and every other field
+  work exactly the same without it — on Android 12+ the SDK detects on `BLUETOOTH_SCAN`,
+  with no location at all. What you lose by skipping it is Wi-Fi in the background, nothing
+  else.
 - **Google Play Data Safety:** the Quick Start already declares **Location**, and Wi-Fi
   observations do not add a new data type to that form — the access point identity travels
-  hashed. If you enable the transitional `ssid` fields, network names do leave the device,
-  which is worth reflecting in your own privacy policy.
+  hashed. But background location itself **does** require a Play Console declaration and a
+  demonstration video. Budget for that review before you promise the feature.
+- If you enable the transitional `ssid` fields, network names do leave the device, which is
+  worth reflecting in your own privacy policy.
 
 Two privacy behaviours are built in: networks whose name ends in `_nomap` (the opt-out
 convention honoured by Google and Mozilla) are dropped on the device, and placeholder

--- a/sdk/src/main/java/io/bearound/sdk/models/UserDevice.kt
+++ b/sdk/src/main/java/io/bearound/sdk/models/UserDevice.kt
@@ -27,6 +27,19 @@ data class UserDevice(
     val coldStart: Boolean,
     val lowPowerMode: Boolean?,
     val locationAccuracy: String?,
+    /**
+     * Whether the host app holds `ACCESS_BACKGROUND_LOCATION`.
+     *
+     * Reported because a `false` here is otherwise **invisible**: from Android 10 on, a
+     * backgrounded app without it gets an empty Wi-Fi scan list and the placeholder BSSID
+     * `02:00:00:00:00:00` instead of an error. The SDK discards the placeholder (as it
+     * must — otherwise every device on earth would map to the same access point), so
+     * `wifis[]` and `network.apId` simply arrive empty, with every permission the app
+     * asked for granted and nothing in any log.
+     *
+     * Always `true` below Android 10, where background location was not a separate grant.
+     */
+    val backgroundLocation: Boolean,
     /** Hash of the connected access point's BSSID — the identity the backend uses. */
     val apId: String?,
     /**

--- a/sdk/src/main/java/io/bearound/sdk/network/APIClient.kt
+++ b/sdk/src/main/java/io/bearound/sdk/network/APIClient.kt
@@ -363,6 +363,9 @@ class APIClient(private val configuration: SDKConfiguration) {
             put("notifications", device.notificationsPermission)
             put("bluetooth", device.bluetoothState)
             device.locationAccuracy?.let { put("locationAccuracy", it) }
+            // Sem isto, Wi-Fi vazio em background e Wi-Fi vazio por falta de permissao sao
+            // indistinguiveis do backend — e a segunda causa nao aparece em log nenhum.
+            put("backgroundLocation", device.backgroundLocation)
             // Advertising ID lives here because that is where the ingest already reads it
             // from (`device.permissions.advertisingId`) — it is provided by the SDK so the
             // backend can skip the matchmaker round-trip.

--- a/sdk/src/main/java/io/bearound/sdk/utilities/DeviceInfoCollector.kt
+++ b/sdk/src/main/java/io/bearound/sdk/utilities/DeviceInfoCollector.kt
@@ -87,6 +87,7 @@ class DeviceInfoCollector(
             coldStart = firstPayloadOfProcess.getAndSet(false),
             lowPowerMode = isLowPowerMode(),
             locationAccuracy = getLocationAccuracy(locationPermission),
+            backgroundLocation = hasBackgroundLocation(),
             apId = wifis.firstOrNull { it.connected }?.apId,
             // Temporary companion to apId while the collection is being validated.
             wifiSSID = wifis.firstOrNull { it.connected }?.ssid,
@@ -132,6 +133,25 @@ class DeviceInfoCollector(
             "denied"
         }
     }
+
+    /**
+     * Whether the host holds `ACCESS_BACKGROUND_LOCATION`.
+     *
+     * The SDK deliberately does **not** declare this permission. It is a dangerous
+     * permission with a Play Store policy review attached, so declaring it here would drag
+     * every host app through that review — including the ones that never collect Wi-Fi.
+     * Declaring it is the host's decision; making its absence visible is ours.
+     *
+     * Measured in production on 2026-08-05: the same device, same session, every permission
+     * it asked for granted, went from 25 access points to zero the instant it was
+     * backgrounded — and nothing anywhere said why.
+     */
+    private fun hasBackgroundLocation(): Boolean =
+        Build.VERSION.SDK_INT < Build.VERSION_CODES.Q ||
+            ContextCompat.checkSelfPermission(
+                context,
+                Manifest.permission.ACCESS_BACKGROUND_LOCATION
+            ) == PackageManager.PERMISSION_GRANTED
 
     private fun getLocationAccuracy(locationPermission: String): String? {
         if (!locationPermission.contains("authorized")) return null


### PR DESCRIPTION
Um cliente em campo estava coletando **zero Wi-Fi** — com todas as permissões que pediu concedidas.

```
ACCESS_FINE_LOCATION    granted=true
NEARBY_WIFI_DEVICES     granted=true
ACCESS_WIFI_STATE       granted=true
```

Reproduzido em device, com corte cirúrgico. Mesmo aparelho, mesma sessão, só mudando o estado:

```
21:43:01   fg=True    wifis=25   apId=2dc5d744…   loc=sim
21:43:02   fg=False   wifis=25   apId=2dc5d744…   loc=sim   ← cache ainda quente
21:43:14   fg=False   wifis=0    apId=None        loc=nao
```

## A causa

`ACCESS_BACKGROUND_LOCATION` não declarada. Do Android 10 em diante, app em background sem ela recebe **lista de scan vazia** e o BSSID placeholder `02:00:00:00:00:00` — sem erro, sem `SecurityException`, nada em logcat.

O SDK descarta o placeholder, e tem de descartar: se hasheasse, todo aparelho do mundo viraria o mesmo AP. Então `wifis[]` e `network.apId` apenas chegam vazios, e nada em lugar nenhum diz por quê.

## E a orientação que levou a isso era nossa

O `AI-AGENT-SETUP.md` mandava, **duas vezes**, não adicionar a permissão:

> *do NOT add or request ACCESS_BACKGROUND_LOCATION — background detection on Android 12+ runs on BLUETOOTH_SCAN, and requesting it drags the app into Google Play's background-location review for zero benefit*

O raciocínio está **certo para beacon**. Detecção no Android 12+ roda em `BLUETOOTH_SCAN`, sem location nenhuma. Mas o texto foi escrito antes da coleta de Wi-Fi existir, e ninguém revisitou quando ela entrou. O integrador fez exatamente o que a gente mandou.

## O que muda

**`device.permissions.backgroundLocation` no payload.** Sem ele, "Wi-Fi vazio porque está em background" e "Wi-Fi vazio por outro motivo" são indistinguíveis do backend — e a primeira causa não aparece em log nenhum. Agora dá para medir a frota inteira em vez de repetir este experimento aparelho a aparelho.

**README** ganha o aviso em destaque e uma seção de como coletar em background, incluindo o segundo prompt separado que o Android 11+ exige (o sistema recusa conceder junto com a localização de foreground e manda o usuário para os Ajustes).

**AI-AGENT-SETUP** deixa de proibir e passa a mandar **perguntar**, com os dois lados explícitos: irrelevante para beacon, decisivo para Wi-Fi de frota, e com custo real de revisão na Play.

## O que continua igual, de propósito

O SDK **não** declara a permissão. Ela é *dangerous*, tem revisão de política da Play atrelada com vídeo de demonstração, e declarar aqui arrastaria **todo** host app para essa revisão — inclusive quem só detecta beacon e nunca toca em Wi-Fi.

Declarar é decisão do integrador. Tornar a ausência visível é nossa.

## Por que isso importa além deste cliente

O Android é o **cartógrafo** da mesh: é ele que vê as ~25 redes vizinhas e permite triangular. O iOS entrega uma só, a conectada.

Hoje o Android só cartografa **enquanto alguém está com o app aberto na mão**. Uma frota vive em background — então na prática o mapa não densificava, e a causa não aparecia em métrica nenhuma.

*(O iOS não sofre disso por acidente: ele já pede `Always` para o olho de Location acordar por região, e `Always` é o equivalente iOS do background location. Confirmado em produção — 37 payloads em background com `authorized_always` e Wi-Fi presente.)*

## Validação

- `:sdk:compileDebugKotlin`, `:sdk:testDebugUnitTest` e `:sdk:lintDebug` ✅
- comportamento reproduzido e medido em device físico (SM-A556E, Android 16)
