### PR TITLE
test(example): declara background location no bench e pede no upgrade

### DIFF
--- a/BearoundScan/src/main/AndroidManifest.xml
+++ b/BearoundScan/src/main/AndroidManifest.xml
@@ -12,9 +12,18 @@
         android:usesPermissionFlags="neverForLocation"
         tools:targetApi="s" />
 
-    <!-- Location for BLE beacon detection on all versions (foreground only; no background). -->
+    <!-- Location for BLE beacon detection on all versions. -->
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <!-- Background location is NOT needed to detect beacons — the scan gate is
+         BLUETOOTH_SCAN on 12+. It is what keeps Wi-Fi observations coming once the app is
+         backgrounded: from Android 10 on, a backgrounded app without it gets an empty scan
+         list and the placeholder BSSID 02:00:00:00:00:00, with no error anywhere. The SDK
+         deliberately does not declare it (it drags every host through a Play policy review
+         with a demo video) — the host declares it if Wi-Fi in background matters, which is
+         exactly what this bench app is for. Check the outcome in the payload:
+         device.permissions.backgroundLocation. -->
+    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
 
     <!-- Network -->
     <uses-permission android:name="android.permission.INTERNET" />

--- a/BearoundScan/src/main/java/io/bearound/bearoundscan/ui/ContentScreen.kt
+++ b/BearoundScan/src/main/java/io/bearound/bearoundscan/ui/ContentScreen.kt
@@ -39,12 +39,25 @@ fun ContentScreen(viewModel: BeaconViewModel = viewModel(), paddingValues: Paddi
     val state by viewModel.state.collectAsState()
     val context = LocalContext.current
 
+    // Background location MUST be its own request: from Android 11 on, asking for it in the
+    // same call as foreground location makes the system deny the whole thing without a
+    // dialog. On 11+ the system dialog also routes through app settings ("Allow all the
+    // time") rather than granting inline.
+    val backgroundLocationLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestPermission()
+    ) { _ ->
+        viewModel.updatePermissionStatus()
+    }
+
     val permissionLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.RequestMultiplePermissions()
-    ) { _ ->
+    ) { granted ->
         viewModel.updatePermissionStatus()
         viewModel.checkBluetoothStatus()
         viewModel.checkNotificationStatus()
+        if (granted[Manifest.permission.ACCESS_FINE_LOCATION] == true) {
+            viewModel.requestBackgroundLocationOnce(backgroundLocationLauncher::launch)
+        }
         // Start scanning once the technical gate is satisfied: BLUETOOTH_SCAN on Android 12+
         // (neverForLocation in the SDK manifest makes Bluetooth-only delivery work, so the
         // scan runs even if location was denied), FINE/COARSE location on Android <= 11.
@@ -56,6 +69,12 @@ fun ContentScreen(viewModel: BeaconViewModel = viewModel(), paddingValues: Paddi
     }
 
     LaunchedEffect(Unit) {
+        // An app that already had the base permissions never reaches the callback above —
+        // which is precisely the app that just added Wi-Fi collection in an update. Ask here
+        // too, or the upgrade path silently never asks.
+        if (viewModel.hasRequiredPermissions()) {
+            viewModel.requestBackgroundLocationOnce(backgroundLocationLauncher::launch)
+        }
         if (!viewModel.hasRequiredPermissions()) {
             val permissions = buildList {
                 add(Manifest.permission.ACCESS_FINE_LOCATION)
@@ -300,6 +319,13 @@ fun PermissionsCard(state: BeAroundScanState) {
                 label = "Localização:",
                 value = state.locationPermissionStatus,
                 color = getLocationPermissionColor(state.locationPermissionStatus)
+            )
+
+            PermissionRow(
+                icon = Icons.Default.LocationOn,
+                label = "Loc. background:",
+                value = state.backgroundLocationStatus,
+                color = getLocationPermissionColor(state.backgroundLocationStatus)
             )
 
             PermissionRow(

--- a/BearoundScan/src/main/java/io/bearound/bearoundscan/viewmodel/BeaconViewModel.kt
+++ b/BearoundScan/src/main/java/io/bearound/bearoundscan/viewmodel/BeaconViewModel.kt
@@ -59,6 +59,7 @@ data class BeAroundScanState(
     val beacons: List<Beacon> = emptyList(),
     val statusMessage: String = "Pronto",
     val locationPermissionStatus: String = "Verificando...",
+    val backgroundLocationStatus: String = "Verificando...",
     val bluetoothStatus: String = "Verificando...",
     val notificationStatus: String = "Verificando...",
     val lastScanTime: Date? = null,
@@ -604,8 +605,49 @@ class BeaconViewModel(application: Application) : AndroidViewModel(application),
             }
         }
 
-        _state.value = _state.value.copy(locationPermissionStatus = locationPermission)
+        val backgroundLocation = when {
+            Build.VERSION.SDK_INT < Build.VERSION_CODES.Q -> "Não se aplica (Android ≤ 9)"
+            hasBackgroundLocation() -> "Concedida — Wi-Fi continua em background"
+            else -> "Negada — Wi-Fi só com o app na tela"
+        }
+
+        _state.value = _state.value.copy(
+            locationPermissionStatus = locationPermission,
+            backgroundLocationStatus = backgroundLocation
+        )
     }
+
+    /**
+     * Asks for background location at most once per install.
+     *
+     * From Android 11 on this does not resolve in a dialog — the system routes to the app's
+     * settings page ("Allow all the time"). Firing it on every cold start would throw the
+     * user into Settings every launch, so the attempt is remembered. Denying is a valid
+     * answer; the row in the UI keeps showing the cost.
+     */
+    fun requestBackgroundLocationOnce(launch: (String) -> Unit) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) return
+        if (hasBackgroundLocation()) return
+        val prefs = getApplication<Application>()
+            .getSharedPreferences("bearoundscan_bench", Context.MODE_PRIVATE)
+        if (prefs.getBoolean("bg_location_asked", false)) return
+        prefs.edit().putBoolean("bg_location_asked", true).apply()
+        launch(Manifest.permission.ACCESS_BACKGROUND_LOCATION)
+    }
+
+    /**
+     * Mirrors what the SDK reports as `device.permissions.backgroundLocation`.
+     *
+     * Not part of the scan gate — beacons are detected without it. It gates the Wi-Fi
+     * observations once the app leaves the screen, and its absence is silent: the system
+     * returns an empty scan list, never an error.
+     */
+    fun hasBackgroundLocation(): Boolean =
+        Build.VERSION.SDK_INT < Build.VERSION_CODES.Q ||
+            ContextCompat.checkSelfPermission(
+                getApplication(),
+                Manifest.permission.ACCESS_BACKGROUND_LOCATION
+            ) == PackageManager.PERMISSION_GRANTED
 
     fun checkBluetoothStatus() {
         val context = getApplication<Application>()


### PR DESCRIPTION
O `BearoundScan` não conseguia testar coleta de Wi-Fi em background porque **não declarava** `ACCESS_BACKGROUND_LOCATION` — a mesma lacuna que o [#82](https://github.com/Bearound/bearound-android-sdk/pull/82) documentou.

## Dois cuidados que a versão ingênua erra

**1. É um request separado.** Do Android 11 em diante, pedir background junto com foreground faz o sistema negar tudo sem mostrar diálogo.

**2. Precisa disparar para quem JÁ tem as permissões base.** O fluxo de permissão só roda quando falta alguma:

```kotlin
if (!viewModel.hasRequiredPermissions()) { /* pede */ }
```

Um app que já tinha location nunca chega no pedido — e esse é **exatamente** o app que acabou de ganhar coleta de Wi-Fi numa atualização. Escrevi essa versão primeiro e ela não pediu nada; só apareceu no teste em device.

O pedido acontece uma vez por instalação. No 11+ ele não resolve em diálogo, abre a tela de configurações do app; disparar a cada cold start jogaria o usuário nas configurações toda vez.

## Validação — Galaxy A55 / Android 16

Mesmo binário, mesma sessão, só a permissão muda:

| fase | app | permissão | `wifis` | payload `backgroundLocation` |
|---|---|---|---|---|
| P1 | foreground | negada | 21 | `false` |
| P2 | background | negada | **0** (11 payloads) | `false` |
| P3 | background | **concedida** | **25** (11 payloads) | `true` |
| P4 | background | revogada | **0** (21 payloads) | `false` |

Payloads lidos do S3, não de log local.

### Conceder e revogar quebram algo?

- **Conceder:** processo sobrevive (mesmo PID). Wi-Fi volta a fluir em ~5s.
- **Revogar:** o Android mata o processo — comportamento padrão para qualquer permissão runtime, não é bug nosso. O `BluetoothScanReceiver` do próprio SDK traz de volta em ~1s (`Start proc 19146 … for broadcast BluetoothScanReceiver`).
- **Zero crash, zero ANR.** Detecção de beacon sem interrupção: os payloads continuaram a cada ~10s durante todo o P4.

A coleta de Wi-Fi degrada para zero **em silêncio**. O sistema até loga:

```
W/WifiService: Permission violation - getScanResults not allowed for uid=10296,
packageName=io.bearound.bearoundscan,
reason=java.lang.SecurityException: UID 10296 has no location permission
```

…mas devolve **lista vazia** ao app em vez de propagar a exceção — por isso o `WifiCollector` não registra nada. Repare que a mensagem diz *"has no location permission"* mesmo com `ACCESS_FINE_LOCATION` concedida: em background ela não conta.

## Um ponto para revisão

O bench passa a **declarar** a permissão, enquanto o SDK deliberadamente não declara (arrastaria todo host para a revisão da Play). São papéis diferentes — o bench existe para testar isto — mas quem copia o example leva a declaração junto. O comentário no manifesto diz isso na cara; se preferirem outro caminho, é o ponto para discutir.